### PR TITLE
Add Arbovirus symbol next to ArboTracker contributors, changed "Alumni" heading to "SeroTracker" alumni.

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -1075,6 +1075,30 @@
         "description": null,
         "fields": [
           {
+            "name": "additionalSymbols",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "TeamMemberSymbol",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "affiliations",
             "description": null,
             "args": [],
@@ -1221,6 +1245,23 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "TeamMemberSymbol",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ARBOTRACKER_SYMBOL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {

--- a/src/api/graphql-types/__generated__/graphql-types.ts
+++ b/src/api/graphql-types/__generated__/graphql-types.ts
@@ -97,6 +97,7 @@ export type Query = {
 
 export type TeamMember = {
   __typename?: 'TeamMember';
+  additionalSymbols: Array<TeamMemberSymbol>;
   affiliations: Array<Affiliation>;
   email?: Maybe<Scalars['String']['output']>;
   firstName: Scalars['String']['output'];
@@ -110,6 +111,10 @@ export type TeamMemberGroup = {
   label: Scalars['String']['output'];
   teamMembers: Array<TeamMember>;
 };
+
+export enum TeamMemberSymbol {
+  ArbotrackerSymbol = 'ARBOTRACKER_SYMBOL'
+}
 
 
 
@@ -193,6 +198,7 @@ export type ResolversTypes = {
   String: ResolverTypeWrapper<Scalars['String']['output']>;
   TeamMember: ResolverTypeWrapper<TeamMember>;
   TeamMemberGroup: ResolverTypeWrapper<TeamMemberGroup>;
+  TeamMemberSymbol: TeamMemberSymbol;
 };
 
 /** Mapping between all available schema types and the resolvers parents */
@@ -290,6 +296,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
 };
 
 export type TeamMemberResolvers<ContextType = any, ParentType extends ResolversParentTypes['TeamMember'] = ResolversParentTypes['TeamMember']> = {
+  additionalSymbols?: Resolver<Array<ResolversTypes['TeamMemberSymbol']>, ParentType, ContextType>;
   affiliations?: Resolver<Array<ResolversTypes['Affiliation']>, ParentType, ContextType>;
   email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   firstName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/src/api/team-resolvers.ts
+++ b/src/api/team-resolvers.ts
@@ -1,5 +1,5 @@
 import { MongoClient } from "mongodb";
-import { QueryResolvers, TeamMemberSymbol } from "./graphql-types/__generated__/graphql-types";
+import { QueryResolvers, TeamMemberSymbol } from "./graphql-types/__generated__/graphql-types.js";
 import { TeamMemberDocument } from "../storage/types";
 
 interface GenerateTeamResolversInput {

--- a/src/api/team-resolvers.ts
+++ b/src/api/team-resolvers.ts
@@ -1,5 +1,5 @@
 import { MongoClient } from "mongodb";
-import { QueryResolvers } from "./graphql-types/__generated__/graphql-types";
+import { QueryResolvers, TeamMemberSymbol } from "./graphql-types/__generated__/graphql-types";
 import { TeamMemberDocument } from "../storage/types";
 
 interface GenerateTeamResolversInput {
@@ -34,7 +34,8 @@ export const generateTeamResolvers = (input: GenerateTeamResolversInput): Genera
               email: "$email",
               twitterUrl: "$twitterUrl",
               linkedinUrl: "$linkedinUrl",
-              affiliations: "$affiliations"
+              affiliations: "$affiliations",
+              arbotrackerContributorFlag: "$arbotrackerContributorFlag"
             }
           }
         }
@@ -56,9 +57,17 @@ export const generateTeamResolvers = (input: GenerateTeamResolversInput): Genera
           }
         }
       }
-    ]).toArray() as Array<{label: string, teamMembers: Pick<TeamMemberDocument, 'firstName'|'lastName'|'email'|'twitterUrl'|'linkedinUrl'|'affiliations'>[]}>;
+    ]).toArray() as Array<{label: string, teamMembers: Pick<TeamMemberDocument, 'firstName'|'lastName'|'email'|'twitterUrl'|'linkedinUrl'|'affiliations'|'arbotrackerContributorFlag'>[]}>;
 
-    return groupedTeamMemberData;
+    return groupedTeamMemberData.map((teamMemberGroup) => ({
+      ...teamMemberGroup,
+      teamMembers: teamMemberGroup.teamMembers.map((teamMember) => ({
+        ...teamMember,
+        additionalSymbols: [
+          ...(teamMember.arbotrackerContributorFlag ? [ TeamMemberSymbol.ArbotrackerSymbol ] : [])
+        ]
+      }))
+    }));
   }
 
   return {

--- a/src/api/team-typedefs.ts
+++ b/src/api/team-typedefs.ts
@@ -7,9 +7,14 @@ export const teamTypedefs = `
     firstName: String!
     lastName: String!
     email: String
+    additionalSymbols: [TeamMemberSymbol!]!
     twitterUrl: String
     linkedinUrl: String
     affiliations: [Affiliation!]!
+  }
+
+  enum TeamMemberSymbol {
+    ARBOTRACKER_SYMBOL
   }
 
   type TeamMemberGroup {

--- a/src/etl/team/steps/clean-field-names-and-remove-unused-fields-step.ts
+++ b/src/etl/team/steps/clean-field-names-and-remove-unused-fields-step.ts
@@ -12,6 +12,7 @@ export interface TeamMemberFieldsAfterCleaningFieldNamesStep {
   affiliationOne: string | undefined;
   affiliationTwo: string | undefined;
   affiliationThree: string | undefined;
+  arbotrackerContributorFlag: boolean;
 }
 
 export interface TeamSortOrderEntryFieldsAfterCleaningFieldNamesStep {
@@ -45,7 +46,8 @@ export const cleanFieldNamesAndRemoveUnusedFieldsStep = (input: CleanFieldNamesA
     linkedinUrl: teamMember["Linkedin URL"],
     affiliationOne: teamMember["Affiliation 1"],
     affiliationTwo: teamMember["Affiliation 2"],
-    affiliationThree: teamMember["Affiliation 3"]
+    affiliationThree: teamMember["Affiliation 3"],
+    arbotrackerContributorFlag: teamMember["ArboTracker"] ?? false
   }))
 
   const teamSortOrder = input.teamSortOrder.map((teamSortOrderEntry) => ({

--- a/src/etl/team/steps/mark-alumni-step.ts
+++ b/src/etl/team/steps/mark-alumni-step.ts
@@ -27,7 +27,7 @@ export const markAlumniStep = (
 
     return {
       ...teamMember,
-      teams: ["Alumni"]
+      teams: ["SeroTracker Alumni"]
     }
   });
 

--- a/src/etl/team/steps/transform-into-format-for-database-step.ts
+++ b/src/etl/team/steps/transform-into-format-for-database-step.ts
@@ -46,6 +46,7 @@ export const transformIntoFormatForDatabaseStep = (
     affiliations: teamMember.affiliations.map((affiliation) => ({
       label: affiliation,
     })),
+    arbotrackerContributorFlag: teamMember.arbotrackerContributorFlag,
     createdAt: createdAtForAllRecords,
     updatedAt: updatedAtForAllRecords,
   }));

--- a/src/etl/team/steps/validate-field-set-from-airtable-step.ts
+++ b/src/etl/team/steps/validate-field-set-from-airtable-step.ts
@@ -32,6 +32,7 @@ export const validateFieldSetFromAirtableStep = (input: ValidateFieldSetFromAirt
     "Affiliation 1": z.string().or(z.undefined()),
     "Affiliation 2": z.string().or(z.undefined()),
     "Affiliation 3": z.string().or(z.undefined()),
+    "ArboTracker": z.boolean().or(z.undefined())
   })
   const allTeamMembers = input.allTeamMembers.map((teamMember) => zodAirtableTeamMemberFieldsObject.parse(teamMember));
 

--- a/src/etl/team/types.ts
+++ b/src/etl/team/types.ts
@@ -10,6 +10,7 @@ export type AirtableTeamMemberFields = {
   "Affiliation 1"?: string | undefined;
   "Affiliation 2"?: string | undefined;
   "Affiliation 3"?: string | undefined;
+  "ArboTracker"?: boolean | undefined;
 };
 
 export type TeamSortOrderEntryFields = {

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -57,6 +57,7 @@ export interface TeamMemberDocument {
   affiliations: Array<{
     label: string;
   }>;
+  arbotrackerContributorFlag: boolean;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
Add Arbovirus symbol next to ArboTracker contributors, changed "Alumni" heading to "SeroTracker" alumni.

![image](https://github.com/serotracker/iit-backend-v2/assets/86806388/687fde05-16dc-4db7-86fe-1d6ef3b21747)