### PR TITLE
Added study name to the SarsCov2 estimates

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -1599,6 +1599,18 @@
             "deprecationReason": null
           },
           {
+            "name": "scope",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "sex",
             "description": null,
             "args": [],
@@ -1807,6 +1819,30 @@
           },
           {
             "name": "riskOfBias",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "scope",
             "description": null,
             "args": [],
             "type": {

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -1635,6 +1635,22 @@
             "deprecationReason": null
           },
           {
+            "name": "studyName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "testType",
             "description": null,
             "args": [],

--- a/src/api/graphql-types/__generated__/graphql-types.ts
+++ b/src/api/graphql-types/__generated__/graphql-types.ts
@@ -154,6 +154,7 @@ export type SarsCov2Estimate = {
   samplingEndDate?: Maybe<Scalars['String']['output']>;
   samplingMidDate?: Maybe<Scalars['String']['output']>;
   samplingStartDate?: Maybe<Scalars['String']['output']>;
+  scope?: Maybe<Scalars['String']['output']>;
   sex?: Maybe<Scalars['String']['output']>;
   sourceType?: Maybe<Scalars['String']['output']>;
   state?: Maybe<Scalars['String']['output']>;
@@ -170,6 +171,7 @@ export type SarsCov2FilterOptions = {
   country: Array<Scalars['String']['output']>;
   isotypes: Array<Scalars['String']['output']>;
   riskOfBias: Array<Scalars['String']['output']>;
+  scope: Array<Scalars['String']['output']>;
   sourceType: Array<Scalars['String']['output']>;
   testType: Array<Scalars['String']['output']>;
   unRegion: Array<UnRegion>;
@@ -442,6 +444,7 @@ export type SarsCov2EstimateResolvers<ContextType = any, ParentType extends Reso
   samplingEndDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   samplingMidDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   samplingStartDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  scope?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   sex?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   sourceType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   state?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -458,6 +461,7 @@ export type SarsCov2FilterOptionsResolvers<ContextType = any, ParentType extends
   country?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   isotypes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   riskOfBias?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  scope?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   sourceType?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   testType?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   unRegion?: Resolver<Array<ResolversTypes['UNRegion']>, ParentType, ContextType>;

--- a/src/api/graphql-types/__generated__/graphql-types.ts
+++ b/src/api/graphql-types/__generated__/graphql-types.ts
@@ -157,6 +157,7 @@ export type SarsCov2Estimate = {
   sex?: Maybe<Scalars['String']['output']>;
   sourceType?: Maybe<Scalars['String']['output']>;
   state?: Maybe<Scalars['String']['output']>;
+  studyName: Scalars['String']['output'];
   testType: Array<Scalars['String']['output']>;
   unRegion?: Maybe<UnRegion>;
   whoRegion?: Maybe<WhoRegion>;
@@ -444,6 +445,7 @@ export type SarsCov2EstimateResolvers<ContextType = any, ParentType extends Reso
   sex?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   sourceType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   state?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  studyName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   testType?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   unRegion?: Resolver<Maybe<ResolversTypes['UNRegion']>, ParentType, ContextType>;
   whoRegion?: Resolver<Maybe<ResolversTypes['WHORegion']>, ParentType, ContextType>;

--- a/src/api/sars-cov-2-resolvers.ts
+++ b/src/api/sars-cov-2-resolvers.ts
@@ -27,6 +27,7 @@ const transformSarsCov2EstimateDocumentForApi = (document: SarsCov2EstimateDocum
     gbdSubRegion: document.gbdSubRegion ? mapGbdSubRegionForApi(document.gbdSubRegion) : undefined,
     gbdSuperRegion: document.gbdSuperRegion ? mapGbdSuperRegionForApi(document.gbdSuperRegion) : undefined,
     state: document.state,
+    scope: document.scope,
     studyName: document.studyName,
     city: document.city,
     populationGroup: document.populationGroup,
@@ -65,6 +66,7 @@ export const generateSarsCov2Resolvers = (input: GenerateSarsCov2ResolversInput)
     const [
       ageGroup,
       country,
+      scope,
       sourceType,
       riskOfBias,
       unRegion,
@@ -75,6 +77,7 @@ export const generateSarsCov2Resolvers = (input: GenerateSarsCov2ResolversInput)
     ] = await Promise.all([
       mongoClient.db(databaseName).collection<SarsCov2EstimateDocument>('sarsCov2Estimates').distinct('ageGroup').then((elements) => filterUndefinedValuesFromArray(elements)),
       mongoClient.db(databaseName).collection<SarsCov2EstimateDocument>('sarsCov2Estimates').distinct('country').then((elements) => filterUndefinedValuesFromArray(elements)),
+      mongoClient.db(databaseName).collection<SarsCov2EstimateDocument>('sarsCov2Estimates').distinct('scope').then((elements) => filterUndefinedValuesFromArray(elements)),
       mongoClient.db(databaseName).collection<SarsCov2EstimateDocument>('sarsCov2Estimates').distinct('sourceType').then((elements) => filterUndefinedValuesFromArray(elements)),
       mongoClient.db(databaseName).collection<SarsCov2EstimateDocument>('sarsCov2Estimates').distinct('riskOfBias').then((elements) => filterUndefinedValuesFromArray(elements)),
       mongoClient.db(databaseName).collection<SarsCov2EstimateDocument>('sarsCov2Estimates').distinct('unRegion').then((elements) => filterUndefinedValuesFromArray(elements)),
@@ -87,6 +90,7 @@ export const generateSarsCov2Resolvers = (input: GenerateSarsCov2ResolversInput)
     return {
       ageGroup,
       country,
+      scope,
       sourceType,
       riskOfBias,
       unRegion: unRegion.map((region) => mapUnRegionForApi(region)),

--- a/src/api/sars-cov-2-resolvers.ts
+++ b/src/api/sars-cov-2-resolvers.ts
@@ -27,6 +27,7 @@ const transformSarsCov2EstimateDocumentForApi = (document: SarsCov2EstimateDocum
     gbdSubRegion: document.gbdSubRegion ? mapGbdSubRegionForApi(document.gbdSubRegion) : undefined,
     gbdSuperRegion: document.gbdSuperRegion ? mapGbdSuperRegionForApi(document.gbdSuperRegion) : undefined,
     state: document.state,
+    studyName: document.studyName,
     city: document.city,
     populationGroup: document.populationGroup,
     riskOfBias: document.riskOfBias,

--- a/src/api/sars-cov-2-typedefs.ts
+++ b/src/api/sars-cov-2-typedefs.ts
@@ -6,6 +6,7 @@ export const sarsCov2Typedefs = `
     testType: [String!]!
     sourceType: String
     riskOfBias: String
+    studyName: String!
     populationGroup: String
     sex: String
     ageGroup: String

--- a/src/api/sars-cov-2-typedefs.ts
+++ b/src/api/sars-cov-2-typedefs.ts
@@ -18,6 +18,7 @@ export const sarsCov2Typedefs = `
     gbdSuperRegion: GBDSuperRegion
     gbdSubRegion: GBDSubRegion
     state: String
+    scope: String
     city: String
     id: String!
     latitude: Float!
@@ -33,6 +34,7 @@ export const sarsCov2Typedefs = `
   type SarsCov2FilterOptions {
     ageGroup: [String!]!
     country: [String!]!
+    scope: [String!]!
     sourceType: [String!]!
     riskOfBias: [String!]!
     unRegion: [UNRegion!]!

--- a/src/etl/sars-cov-2/steps/add-country-and-region-information-step.ts
+++ b/src/etl/sars-cov-2/steps/add-country-and-region-information-step.ts
@@ -1,4 +1,4 @@
-import { EstimateFieldsAfterParsingDatesStep, StructuredPositiveCaseDataAfterParsingDatesStep, StructuredVaccinationDataAfterParsingDatesStep } from "./parse-dates-step.js";
+import { EstimateFieldsAfterParsingDatesStep, StructuredPositiveCaseDataAfterParsingDatesStep, StructuredVaccinationDataAfterParsingDatesStep, StudyFieldsAfterParsingDatesStep } from "./parse-dates-step.js";
 import { UNRegion, getUNRegionFromAlphaTwoCode } from "../../../lib/un-regions.js";
 import { WHORegion, getWHORegionFromAlphaTwoCode } from "../../../lib/who-regions.js";
 import { GBDSubRegion, GBDSuperRegion, getGBDRegionFromAlphaTwoCode } from "../../../lib/gbd-regions.js";
@@ -11,17 +11,20 @@ export type EstimateFieldsAfterAddingCountryAndRegionInformationStep = EstimateF
   gbdSubRegion: GBDSubRegion | undefined;
   countryAlphaTwoCode: TwoLetterIsoCountryCode;
 };
+export type StudyFieldsAfterAddingCountryAndRegionInformationStep = StudyFieldsAfterParsingDatesStep;
 export type StructuredVaccinationDataAfterAddingCountryAndRegionInformationStep = StructuredVaccinationDataAfterParsingDatesStep;
 export type StructuredPositiveCaseDataAfterAddingCountryAndRegionInformationStep = StructuredPositiveCaseDataAfterParsingDatesStep;
 
 interface AddCountryAndRegionInformationStepInput {
   allEstimates: EstimateFieldsAfterParsingDatesStep[];
+  allStudies: StudyFieldsAfterParsingDatesStep[];
   vaccinationData: StructuredVaccinationDataAfterParsingDatesStep;
   positiveCaseData: StructuredPositiveCaseDataAfterParsingDatesStep;
 }
 
 interface AddCountryAndRegionInformationStepOutput {
   allEstimates: EstimateFieldsAfterAddingCountryAndRegionInformationStep[];
+  allStudies: StudyFieldsAfterAddingCountryAndRegionInformationStep[];
   vaccinationData: StructuredVaccinationDataAfterAddingCountryAndRegionInformationStep;
   positiveCaseData: StructuredPositiveCaseDataAfterAddingCountryAndRegionInformationStep;
 }
@@ -57,6 +60,7 @@ export const addCountryAndRegionInformationStep = (input: AddCountryAndRegionInf
           gbdSubRegion
         };
       }).filter(<T>(estimate: T | undefined): estimate is T => !!estimate),
+    allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
   };

--- a/src/etl/sars-cov-2/steps/add-positive-case-data-to-estimate-step.ts
+++ b/src/etl/sars-cov-2/steps/add-positive-case-data-to-estimate-step.ts
@@ -1,9 +1,11 @@
-import { EstimateFieldsAfterAddingVaccinationDataStep, StructuredPositiveCaseDataAfterAddingVaccinationDataStep, StructuredVaccinationDataAfterAddingVaccinationDataStep } from "./add-vaccination-data-to-estimate-step";
+import { EstimateFieldsAfterAddingVaccinationDataStep, StructuredPositiveCaseDataAfterAddingVaccinationDataStep, StructuredVaccinationDataAfterAddingVaccinationDataStep, StudyFieldsAfterAddingVaccinationDataStep } from "./add-vaccination-data-to-estimate-step";
 
 export type EstimateFieldsAfterAddingPositiveCaseDataStep =
   EstimateFieldsAfterAddingVaccinationDataStep & { 
     countryPositiveCasesPerMillionPeople: number | undefined;
   };
+export type StudyFieldsAfterAddingPositiveCaseDataStep =
+  StudyFieldsAfterAddingVaccinationDataStep;
 export type StructuredVaccinationDataAfterAddingPositiveCaseDataStep =
   StructuredVaccinationDataAfterAddingVaccinationDataStep;
 export type StructuredPositiveCaseDataAfterAddingPositiveCaseDataStep =
@@ -11,12 +13,14 @@ export type StructuredPositiveCaseDataAfterAddingPositiveCaseDataStep =
 
 interface AddPositiveCaseDataToEstimateStepInput {
   allEstimates: EstimateFieldsAfterAddingVaccinationDataStep[];
+  allStudies: StudyFieldsAfterAddingVaccinationDataStep[];
   vaccinationData: StructuredVaccinationDataAfterAddingVaccinationDataStep;
   positiveCaseData: StructuredPositiveCaseDataAfterAddingVaccinationDataStep;
 }
 
 interface AddPositiveCaseDataToEstimateStepOutput {
   allEstimates: EstimateFieldsAfterAddingPositiveCaseDataStep[];
+  allStudies: StudyFieldsAfterAddingPositiveCaseDataStep[];
   vaccinationData: StructuredVaccinationDataAfterAddingPositiveCaseDataStep;
   positiveCaseData: StructuredPositiveCaseDataAfterAddingPositiveCaseDataStep;
 }
@@ -37,6 +41,7 @@ export const addPositiveCaseDataToEstimateStep = (
         .find((element) => estimate.samplingMidDate && element.month === (estimate.samplingMidDate.getUTCMonth() + 1).toString())?.data
         .find((element) => estimate.samplingMidDate && element.day === (estimate.samplingMidDate.getUTCDate()).toString())?.countryPositiveCasesPerMillionPeople
     })),
+    allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
   };

--- a/src/etl/sars-cov-2/steps/add-vaccination-data-to-estimate-step.ts
+++ b/src/etl/sars-cov-2/steps/add-vaccination-data-to-estimate-step.ts
@@ -2,6 +2,7 @@ import {
   EstimateFieldsAfterJitteringPinLatLngStep,
   StructuredPositiveCaseDataAfterJitteringPinLatLngStep,
   StructuredVaccinationDataAfterJitteringPinLatLngStep,
+  StudyFieldsAfterJitteringPinLatLngStep,
 } from "./jitter-pin-lat-lng-step";
 
 export type EstimateFieldsAfterAddingVaccinationDataStep =
@@ -9,6 +10,7 @@ export type EstimateFieldsAfterAddingVaccinationDataStep =
     countryPeopleVaccinatedPerHundred: number | undefined;
     countryPeopleFullyVaccinatedPerHundred: number | undefined;
   };
+export type StudyFieldsAfterAddingVaccinationDataStep = StudyFieldsAfterJitteringPinLatLngStep;
 export type StructuredVaccinationDataAfterAddingVaccinationDataStep =
   StructuredVaccinationDataAfterJitteringPinLatLngStep;
 export type StructuredPositiveCaseDataAfterAddingVaccinationDataStep =
@@ -16,12 +18,14 @@ export type StructuredPositiveCaseDataAfterAddingVaccinationDataStep =
 
 interface AddVaccinationDataToEstimateStepInput {
   allEstimates: EstimateFieldsAfterJitteringPinLatLngStep[];
+  allStudies: StudyFieldsAfterJitteringPinLatLngStep[];
   vaccinationData: StructuredVaccinationDataAfterJitteringPinLatLngStep;
   positiveCaseData: StructuredPositiveCaseDataAfterJitteringPinLatLngStep;
 }
 
 interface AddVaccinationDataToEstimateStepOutput {
   allEstimates: EstimateFieldsAfterAddingVaccinationDataStep[];
+  allStudies: StudyFieldsAfterAddingVaccinationDataStep[];
   vaccinationData: StructuredVaccinationDataAfterAddingVaccinationDataStep;
   positiveCaseData: StructuredPositiveCaseDataAfterAddingVaccinationDataStep;
 }
@@ -52,6 +56,7 @@ export const addVaccinationDataToEstimateStep = (
         countryPeopleFullyVaccinatedPerHundred
       }
     }),
+    allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
   };

--- a/src/etl/sars-cov-2/steps/clean-field-names-and-remove-unused-fields-step.ts
+++ b/src/etl/sars-cov-2/steps/clean-field-names-and-remove-unused-fields-step.ts
@@ -1,5 +1,5 @@
 import { isArrayOfUnknownType } from "../../../lib/lib.js";
-import { EstimateFieldsAfterValidatingFieldSetFromAirtableStep, StructuredPositiveCaseDataAfterValidatingFieldSetFromAirtableStep, StructuredVaccinationDataAfterValidatingFieldSetFromAirtableStep } from "./validate-field-set-from-airtable-step.js";
+import { EstimateFieldsAfterValidatingFieldSetFromAirtableStep, StructuredPositiveCaseDataAfterValidatingFieldSetFromAirtableStep, StructuredVaccinationDataAfterValidatingFieldSetFromAirtableStep, StudyFieldsAfterValidatingFieldSetFromAirtableStep } from "./validate-field-set-from-airtable-step.js";
 import { isAirtableError, AirtableError } from "../types.js";
 
 export interface EstimateFieldsAfterCleaningFieldNamesStep {
@@ -22,30 +22,37 @@ export interface EstimateFieldsAfterCleaningFieldNamesStep {
   scope: string | undefined;
   samplingEndDate: string | undefined;
   samplingStartDate: string | undefined;
+  studyId: string | undefined;
+}
+export interface StudyFieldsAfterCleaningFieldNamesStep {
+  id: string;
+  studyName: string | undefined;
 }
 export type StructuredVaccinationDataAfterCleaningFieldNamesStep = StructuredVaccinationDataAfterValidatingFieldSetFromAirtableStep;
 export type StructuredPositiveCaseDataAfterCleaningFieldNamesStep = StructuredPositiveCaseDataAfterValidatingFieldSetFromAirtableStep;
 
 interface CleanFieldNamesAndRemoveUnusedFieldsStepInput {
   allEstimates: EstimateFieldsAfterValidatingFieldSetFromAirtableStep[];
+  allStudies: StudyFieldsAfterValidatingFieldSetFromAirtableStep[];
   vaccinationData: StructuredVaccinationDataAfterValidatingFieldSetFromAirtableStep;
   positiveCaseData: StructuredPositiveCaseDataAfterValidatingFieldSetFromAirtableStep;
 }
 
 interface CleanFieldNamesAndRemoveUnusedFieldsStepOutput {
   allEstimates: EstimateFieldsAfterCleaningFieldNamesStep[];
+  allStudies: StudyFieldsAfterCleaningFieldNamesStep[];
   vaccinationData: StructuredVaccinationDataAfterCleaningFieldNamesStep;
   positiveCaseData: StructuredPositiveCaseDataAfterCleaningFieldNamesStep;
 }
 
 interface CleanArrayFieldToSingleValueInput<
   TFieldName extends string,
-  TEstimate extends Record<TFieldName, Array<string | null | AirtableError>> & {
+  TObject extends Record<TFieldName, Array<string | null | AirtableError>> & {
     id: string;
   },
 > {
   key: TFieldName;
-  estimate: TEstimate;
+  object: TObject;
 }
 
 interface CleanArrayFieldToSingleValueOutput {
@@ -54,19 +61,19 @@ interface CleanArrayFieldToSingleValueOutput {
 
 const cleanArrayFieldToSingleValue = <
   TFieldName extends string,
-  TEstimate extends Record<TFieldName, Array<string | null | AirtableError>> & {
+  TObject extends Record<TFieldName, Array<string | null | AirtableError>> & {
     id: string;
   },
 >(
-  input: CleanArrayFieldToSingleValueInput<TFieldName, TEstimate>
+  input: CleanArrayFieldToSingleValueInput<TFieldName, TObject>
 ): CleanArrayFieldToSingleValueOutput => {
-  const inputValue = input.estimate[input.key].filter(
+  const inputValue = input.object[input.key].filter(
     <T>(element: T | AirtableError): element is T => !isAirtableError(element)
   );
 
   if (inputValue.length > 1) {
     console.error(
-      `Unable to clean array field "${input.key}" with more than one element for estimate with id ${input.estimate.id}`
+      `Unable to clean array field "${input.key}" with more than one element for object with id ${input.object.id}`
     );
   }
 
@@ -77,12 +84,12 @@ const cleanArrayFieldToSingleValue = <
 
 interface ConvertSingleValueOrArrayToArrayInput<
   TFieldName extends string,
-  TEstimate extends Record<TFieldName, string | null | Array<string | null>> & {
+  TObject extends Record<TFieldName, string | null | Array<string | null>> & {
     id: string;
   },
 > {
   key: TFieldName;
-  estimate: TEstimate;
+  object: TObject;
 }
 
 interface ConvertSingleValueOrArrayToArrayOutput {
@@ -91,13 +98,13 @@ interface ConvertSingleValueOrArrayToArrayOutput {
 
 const convertSingleValueOrArrayToArray = <
   TFieldName extends string,
-  TEstimate extends Record<TFieldName, string | null | Array<string | null>> & {
+  TObject extends Record<TFieldName, string | null | Array<string | null>> & {
     id: string;
   },
 >(
-  input: ConvertSingleValueOrArrayToArrayInput<TFieldName, TEstimate>
+  input: ConvertSingleValueOrArrayToArrayInput<TFieldName, TObject>
 ): ConvertSingleValueOrArrayToArrayOutput => {
-  const inputValue = input.estimate[input.key];
+  const inputValue = input.object[input.key];
 
   if (!inputValue) {
     return { value: [] };
@@ -126,35 +133,35 @@ export const cleanFieldNamesAndRemoveUnusedFieldsStep = (
       id: estimate.id,
       antibodies: convertSingleValueOrArrayToArray({
         key: "Antibody target",
-        estimate,
+        object: estimate,
       }).value.flatMap((antibodyString) => {
         return [...new Set(antibodyString.split(',').map((element) => element.trim()).filter((element) => !!element))]
       }),
       isotypes: convertSingleValueOrArrayToArray({
         key: "Isotype(s) Reported",
-        estimate,
+        object: estimate,
       }).value.flatMap((isotypeString) => {
         return [...new Set(isotypeString.split(',').map((element) => element.trim()).filter((element) => !!element))]
       }),
       isWHOUnityAligned:
         cleanArrayFieldToSingleValue({
           key: "UNITY: Criteria",
-          estimate,
+          object: estimate,
         }).value === "Unity-Aligned"
           ? true
           : false,
       testType: estimate["Test Type"] ? [...new Set(estimate["Test Type"].split(',').map((element) => element.trim()).filter((element) => !!element))] : [],
       sourceType: cleanArrayFieldToSingleValue({
         key: "Source Type",
-        estimate,
+        object: estimate,
       }).value,
       riskOfBias: cleanArrayFieldToSingleValue({
         key: "Overall Risk of Bias (JBI)",
-        estimate,
+        object: estimate,
       }).value,
       countryAlphaThreeCode: cleanArrayFieldToSingleValue({
         key: 'Alpha3 Code',
-        estimate
+        object: estimate,
       }).value,
       ageGroup: estimate["Sample Frame (age)"] ?? undefined,
       sex: estimate["Sample Frame (sex)"] ?? undefined,
@@ -168,6 +175,17 @@ export const cleanFieldNamesAndRemoveUnusedFieldsStep = (
       scope: estimate["Grade of Estimate Scope"] ?? undefined,
       samplingEndDate: estimate["Sampling End Date"] ?? undefined,
       samplingStartDate: estimate["Sampling End Date"] ?? undefined,
+      studyId: cleanArrayFieldToSingleValue({
+        key: "Rapid Review: Study",
+        object: estimate,
+      }).value
+    })),
+    allStudies: input.allStudies.map((study) => ({
+      id: study.id,
+      studyName: cleanArrayFieldToSingleValue({
+        key: "Source Name (from Rapid Review: Source)",
+        object: study,
+      }).value
     })),
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,

--- a/src/etl/sars-cov-2/steps/combine-estimates-and-studies-step.ts
+++ b/src/etl/sars-cov-2/steps/combine-estimates-and-studies-step.ts
@@ -1,0 +1,56 @@
+import {
+  EstimateFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep,
+  StructuredPositiveCaseDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep,
+  StructuredVaccinationDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep,
+  StudyFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep,
+} from "./remove-records-that-are-flagged-to-not-save-step.js";
+
+export type EstimateFieldsAfterCombiningEstimatesAndStudiesStep = EstimateFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep & {studyName: string | undefined};
+export type StudyFieldsAfterCombiningEstimatesAndStudiesStep = StudyFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep;
+export type StructuredVaccinationDataAfterAfterCombiningEstimatesAndStudiesStep =
+  StructuredVaccinationDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep;
+export type StructuredPositiveCaseDataAfterAfterCombiningEstimatesAndStudiesStep =
+  StructuredPositiveCaseDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep;
+
+interface CombineEstimatesAndStudiesInput {
+  allEstimates: EstimateFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep[];
+  allStudies: StudyFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep[];
+  vaccinationData: StructuredVaccinationDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep;
+  positiveCaseData: StructuredPositiveCaseDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep;
+}
+
+interface CombineEstimatesAndStudiesOutput {
+  allEstimates: EstimateFieldsAfterCombiningEstimatesAndStudiesStep[];
+  allStudies: StudyFieldsAfterCombiningEstimatesAndStudiesStep[];
+  vaccinationData: StructuredVaccinationDataAfterAfterCombiningEstimatesAndStudiesStep;
+  positiveCaseData: StructuredPositiveCaseDataAfterAfterCombiningEstimatesAndStudiesStep;
+}
+
+export const combineEstimatesAndStudies = (
+  input: CombineEstimatesAndStudiesInput
+): CombineEstimatesAndStudiesOutput => {
+  console.log(
+    `Running step: combineEstimatesAndStudies. Remaining estimates: ${input.allEstimates.length}`
+  );
+
+  return {
+    allEstimates: input.allEstimates.map((estimate) => {
+      const associatedStudy = input.allStudies.find((study) => study.id === estimate.studyId);
+
+      if(!associatedStudy) {
+        return {
+          ...estimate,
+          studyName: undefined
+        }
+      }
+
+      return {
+        ...estimate,
+        studyName: associatedStudy.studyName
+      }
+    }),
+    allStudies: input.allStudies,
+    vaccinationData: input.vaccinationData,
+    positiveCaseData: input.positiveCaseData,
+  };
+};

--- a/src/etl/sars-cov-2/steps/fetch-positive-case-data-step.ts
+++ b/src/etl/sars-cov-2/steps/fetch-positive-case-data-step.ts
@@ -1,21 +1,24 @@
 import { request } from "undici";
 import { StructuredPositiveCaseData } from "../types";
-import { EstimateFieldsAfterFetchingVaccinationDataStep, StructuredPositiveCaseDataAfterFetchingVaccinationDataStep, StructuredVaccinationDataAfterFetchingVaccinationDataStep } from "./fetch-vaccination-data-step";
+import { EstimateFieldsAfterFetchingVaccinationDataStep, StructuredPositiveCaseDataAfterFetchingVaccinationDataStep, StructuredVaccinationDataAfterFetchingVaccinationDataStep, StudyFieldsAfterFetchingVaccinationDataStep } from "./fetch-vaccination-data-step";
 import { TwoLetterIsoCountryCode } from "../../../lib/geocoding-api/country-codes";
 import { groupByArray, typedObjectEntries } from "../../../lib/lib.js";
 
 export type EstimateFieldsAfterFetchingPositiveCaseDataStep = EstimateFieldsAfterFetchingVaccinationDataStep;
+export type StudyFieldsAfterFetchingPositiveCaseDataStep = StudyFieldsAfterFetchingVaccinationDataStep;
 export type StructuredVaccinationDataAfterFetchingPositiveCaseDataStep = StructuredVaccinationDataAfterFetchingVaccinationDataStep;
 export type StructuredPositiveCaseDataAfterFetchingPositiveCaseDataStep = StructuredPositiveCaseData;
 
 interface FetchPositiveCaseDataStepInput {
   allEstimates: EstimateFieldsAfterFetchingVaccinationDataStep[];
+  allStudies: StudyFieldsAfterFetchingVaccinationDataStep[];
   vaccinationData: StructuredVaccinationDataAfterFetchingVaccinationDataStep;
   positiveCaseData: StructuredPositiveCaseDataAfterFetchingVaccinationDataStep;
 }
 
 interface FetchPositiveCaseDataStepOutput {
   allEstimates: EstimateFieldsAfterFetchingPositiveCaseDataStep[];
+  allStudies: StudyFieldsAfterFetchingPositiveCaseDataStep[];
   vaccinationData: StructuredVaccinationDataAfterFetchingPositiveCaseDataStep;
   positiveCaseData: StructuredPositiveCaseDataAfterFetchingPositiveCaseDataStep;
 }
@@ -297,6 +300,7 @@ export const fetchPositiveCaseDataStep = async(
 
   return {
     allEstimates: input.allEstimates,
+    allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: formattedPositiveCaseData,
   };

--- a/src/etl/sars-cov-2/steps/fetch-vaccination-data-step.ts
+++ b/src/etl/sars-cov-2/steps/fetch-vaccination-data-step.ts
@@ -4,6 +4,7 @@ import { request } from "undici";
 import { groupByArray } from "../../../lib/lib.js";
 
 export type EstimateFieldsAfterFetchingVaccinationDataStep = FieldSet;
+export type StudyFieldsAfterFetchingVaccinationDataStep = FieldSet;
 export type StructuredVaccinationDataAfterFetchingVaccinationDataStep =
   StructuredVaccinationData;
 export type StructuredPositiveCaseDataAfterFetchingVaccinationDataStep =
@@ -11,12 +12,14 @@ export type StructuredPositiveCaseDataAfterFetchingVaccinationDataStep =
 
 interface FetchVaccinationDataStepInput {
   allEstimates: FieldSet[];
+  allStudies: FieldSet[];
   vaccinationData: undefined;
   positiveCaseData: undefined;
 }
 
 interface FetchVaccinationDataStepOutput {
   allEstimates: EstimateFieldsAfterFetchingVaccinationDataStep[];
+  allStudies: StudyFieldsAfterFetchingVaccinationDataStep[];
   vaccinationData: StructuredVaccinationDataAfterFetchingVaccinationDataStep;
   positiveCaseData: StructuredPositiveCaseDataAfterFetchingVaccinationDataStep;
 }
@@ -74,6 +77,7 @@ export const fetchVaccinationDataStep = async (
 
   return {
     allEstimates: input.allEstimates,
+    allStudies: input.allStudies,
     vaccinationData: formattedVaccinationData,
     positiveCaseData: input.positiveCaseData,
   };

--- a/src/etl/sars-cov-2/steps/filter-studies-that-do-not-meet-data-structure-requirements.ts
+++ b/src/etl/sars-cov-2/steps/filter-studies-that-do-not-meet-data-structure-requirements.ts
@@ -1,27 +1,32 @@
 import {
-  EstimateFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep,
-  StructuredPositiveCaseDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep,
-  StructuredVaccinationDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep,
-} from "./remove-records-that-are-flagged-to-not-save-step.js";
+  EstimateFieldsAfterCombiningEstimatesAndStudiesStep,
+  StructuredPositiveCaseDataAfterAfterCombiningEstimatesAndStudiesStep,
+  StructuredVaccinationDataAfterAfterCombiningEstimatesAndStudiesStep,
+  StudyFieldsAfterCombiningEstimatesAndStudiesStep
+} from "./combine-estimates-and-studies-step.js";
 
 export type EstimateFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep =
   Omit<
-    EstimateFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep,
-    "country" | "countryAlphaThreeCode"
-  > & { country: string; countryAlphaThreeCode: string };
+    EstimateFieldsAfterCombiningEstimatesAndStudiesStep,
+    "country" | "countryAlphaThreeCode" | "studyName"
+  > & { country: string; countryAlphaThreeCode: string, studyName: string };
+export type StudyFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep =
+  StudyFieldsAfterCombiningEstimatesAndStudiesStep;
 export type StructuredVaccinationDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep =
-  StructuredVaccinationDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep;
+  StructuredVaccinationDataAfterAfterCombiningEstimatesAndStudiesStep;
 export type StructuredPositiveCaseDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep =
-  StructuredPositiveCaseDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep;
+  StructuredPositiveCaseDataAfterAfterCombiningEstimatesAndStudiesStep;
 
 interface FilterStudiesThatDoNotMeetDataStructureRequirementsInput {
-  allEstimates: EstimateFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep[];
-  vaccinationData: StructuredVaccinationDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep;
-  positiveCaseData: StructuredPositiveCaseDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep;
+  allEstimates: EstimateFieldsAfterCombiningEstimatesAndStudiesStep[];
+  allStudies: StudyFieldsAfterCombiningEstimatesAndStudiesStep[];
+  vaccinationData: StructuredVaccinationDataAfterAfterCombiningEstimatesAndStudiesStep;
+  positiveCaseData: StructuredPositiveCaseDataAfterAfterCombiningEstimatesAndStudiesStep;
 }
 
 interface FilterStudiesThatDoNotMeetDataStructureRequirementsOutput {
   allEstimates: EstimateFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep[];
+  allStudies: StudyFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep[];
   vaccinationData: StructuredVaccinationDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep;
   positiveCaseData: StructuredPositiveCaseDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep;
 }
@@ -38,8 +43,9 @@ export const filterStudiesThatDoNotMeetDataStructureRequirement = (
       (
         estimate
       ): estimate is EstimateFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep =>
-        !!estimate.country && !!estimate.countryAlphaThreeCode
+        !!estimate.country && !!estimate.countryAlphaThreeCode && !!estimate.studyName
     ),
+    allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
   };

--- a/src/etl/sars-cov-2/steps/jitter-pin-lat-lng-step.ts
+++ b/src/etl/sars-cov-2/steps/jitter-pin-lat-lng-step.ts
@@ -1,7 +1,9 @@
-import { EstimateFieldsAfterLatLngGenerationStep, StructuredPositiveCaseDataAfterLatLngGenerationStep, StructuredVaccinationDataAfterLatLngGenerationStep } from "./lat-lng-generation-step.js";
+import { EstimateFieldsAfterLatLngGenerationStep, StructuredPositiveCaseDataAfterLatLngGenerationStep, StructuredVaccinationDataAfterLatLngGenerationStep, StudyFieldsAfterLatLngGenerationStep } from "./lat-lng-generation-step.js";
 
 export type EstimateFieldsAfterJitteringPinLatLngStep =
   EstimateFieldsAfterLatLngGenerationStep;
+export type StudyFieldsAfterJitteringPinLatLngStep =
+  StudyFieldsAfterLatLngGenerationStep;
 export type StructuredVaccinationDataAfterJitteringPinLatLngStep = StructuredVaccinationDataAfterLatLngGenerationStep;
 export type StructuredPositiveCaseDataAfterJitteringPinLatLngStep = StructuredPositiveCaseDataAfterLatLngGenerationStep;
 
@@ -25,12 +27,14 @@ const jitterNumberValueByAmount = (
 
 interface JitterPinLatLngStepInput {
   allEstimates: EstimateFieldsAfterLatLngGenerationStep[];
+  allStudies: StudyFieldsAfterLatLngGenerationStep[];
   vaccinationData: StructuredVaccinationDataAfterLatLngGenerationStep;
   positiveCaseData: StructuredPositiveCaseDataAfterLatLngGenerationStep;
 }
 
 interface JitterPinLatLngStepOutput {
   allEstimates: EstimateFieldsAfterJitteringPinLatLngStep[];
+  allStudies: StudyFieldsAfterJitteringPinLatLngStep[];
   vaccinationData: StructuredVaccinationDataAfterJitteringPinLatLngStep;
   positiveCaseData: StructuredPositiveCaseDataAfterJitteringPinLatLngStep;
 }
@@ -57,6 +61,7 @@ export const jitterPinLatLngStep = (
         jitterAmount: maximumPinJitterMagnitude,
       }),
     })),
+    allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
   };

--- a/src/etl/sars-cov-2/steps/lat-lng-generation-step.ts
+++ b/src/etl/sars-cov-2/steps/lat-lng-generation-step.ts
@@ -1,5 +1,5 @@
 import { writeFileSync } from "fs";
-import { EstimateFieldsAfterAddingCountryAndRegionInformationStep, StructuredPositiveCaseDataAfterAddingCountryAndRegionInformationStep, StructuredVaccinationDataAfterAddingCountryAndRegionInformationStep } from "./add-country-and-region-information-step";
+import { EstimateFieldsAfterAddingCountryAndRegionInformationStep, StructuredPositiveCaseDataAfterAddingCountryAndRegionInformationStep, StructuredVaccinationDataAfterAddingCountryAndRegionInformationStep, StudyFieldsAfterAddingCountryAndRegionInformationStep } from "./add-country-and-region-information-step";
 import { Point } from "../../../lib/geocoding-api/geocoding-api-client-types.js";
 import { getCityLatLng } from "../../../lib/geocoding-api/geocoding-functions.js";
 import { getLatitude, getLongitude } from "../../../lib/geocoding-api/coordinate-helpers.js";
@@ -8,17 +8,20 @@ export type EstimateFieldsAfterLatLngGenerationStep = EstimateFieldsAfterAddingC
   latitude: number;
   longitude: number;
 };
+export type StudyFieldsAfterLatLngGenerationStep = StudyFieldsAfterAddingCountryAndRegionInformationStep;
 export type StructuredVaccinationDataAfterLatLngGenerationStep = StructuredVaccinationDataAfterAddingCountryAndRegionInformationStep;
 export type StructuredPositiveCaseDataAfterLatLngGenerationStep = StructuredPositiveCaseDataAfterAddingCountryAndRegionInformationStep;
 
 interface LatLngGenerationStepInput {
   allEstimates: EstimateFieldsAfterAddingCountryAndRegionInformationStep[];
+  allStudies: StudyFieldsAfterAddingCountryAndRegionInformationStep[];
   vaccinationData: StructuredVaccinationDataAfterAddingCountryAndRegionInformationStep;
   positiveCaseData: StructuredPositiveCaseDataAfterAddingCountryAndRegionInformationStep;
 }
 
 interface LatLngGenerationStepOutput {
   allEstimates: EstimateFieldsAfterLatLngGenerationStep[];
+  allStudies: StudyFieldsAfterLatLngGenerationStep[];
   vaccinationData: StructuredVaccinationDataAfterLatLngGenerationStep;
   positiveCaseData: StructuredPositiveCaseDataAfterLatLngGenerationStep;
 }
@@ -65,6 +68,7 @@ export const latLngGenerationStep = async(
 
   return {
     allEstimates: estimatesWithLatitudesAndLongitudes,
+    allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
   };

--- a/src/etl/sars-cov-2/steps/parse-dates-step.ts
+++ b/src/etl/sars-cov-2/steps/parse-dates-step.ts
@@ -1,22 +1,25 @@
 import { parse } from "date-fns";
-import { EstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep, StructuredPositiveCaseDataAfterTransformingNotReportedValuesToUndefinedStep, StructuredVaccinationDataAfterTransformingNotReportedValuesToUndefinedStep } from "./transform-not-reported-values-to-undefined-step.js";
+import { EstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep, StructuredPositiveCaseDataAfterTransformingNotReportedValuesToUndefinedStep, StructuredVaccinationDataAfterTransformingNotReportedValuesToUndefinedStep, StudyFieldsAfterTransformingNotReportedValuesToUndefinedStep } from "./transform-not-reported-values-to-undefined-step.js";
 
 export type EstimateFieldsAfterParsingDatesStep = Omit<EstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep, 'samplingEndDate' | 'samplingStartDate'> & {
   samplingStartDate: Date | undefined;
   samplingEndDate: Date | undefined;
   samplingMidDate: Date | undefined;
 };
+export type StudyFieldsAfterParsingDatesStep = StudyFieldsAfterTransformingNotReportedValuesToUndefinedStep;
 export type StructuredVaccinationDataAfterParsingDatesStep = StructuredVaccinationDataAfterTransformingNotReportedValuesToUndefinedStep;
 export type StructuredPositiveCaseDataAfterParsingDatesStep = StructuredPositiveCaseDataAfterTransformingNotReportedValuesToUndefinedStep;
 
 interface ParseDatesStepInput {
   allEstimates: EstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
+  allStudies: StudyFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
   vaccinationData: StructuredVaccinationDataAfterTransformingNotReportedValuesToUndefinedStep;
   positiveCaseData: StructuredPositiveCaseDataAfterTransformingNotReportedValuesToUndefinedStep;
 }
 
 interface ParseDatesStepOutput {
   allEstimates: EstimateFieldsAfterParsingDatesStep[];
+  allStudies: StudyFieldsAfterParsingDatesStep[];
   vaccinationData: StructuredVaccinationDataAfterParsingDatesStep;
   positiveCaseData: StructuredPositiveCaseDataAfterParsingDatesStep;
 }
@@ -39,6 +42,7 @@ export const parseDatesStep = (input: ParseDatesStepInput): ParseDatesStepOutput
         samplingMidDate, 
       };
     }),
+    allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
   };

--- a/src/etl/sars-cov-2/steps/remove-records-that-are-flagged-to-not-save-step.ts
+++ b/src/etl/sars-cov-2/steps/remove-records-that-are-flagged-to-not-save-step.ts
@@ -1,18 +1,22 @@
-import { EstimateFieldsAfterCleaningFieldNamesStep, StructuredPositiveCaseDataAfterCleaningFieldNamesStep, StructuredVaccinationDataAfterCleaningFieldNamesStep } from "./clean-field-names-and-remove-unused-fields-step.js";
+import { EstimateFieldsAfterCleaningFieldNamesStep, StructuredPositiveCaseDataAfterCleaningFieldNamesStep, StructuredVaccinationDataAfterCleaningFieldNamesStep, StudyFieldsAfterCleaningFieldNamesStep } from "./clean-field-names-and-remove-unused-fields-step.js";
 
 export type EstimateFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep =
   EstimateFieldsAfterCleaningFieldNamesStep;
+export type StudyFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep =
+  StudyFieldsAfterCleaningFieldNamesStep;
 export type StructuredVaccinationDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep = StructuredVaccinationDataAfterCleaningFieldNamesStep;
 export type StructuredPositiveCaseDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep = StructuredPositiveCaseDataAfterCleaningFieldNamesStep;
 
 interface RemoveRecordsThatAreFlaggedNotToSaveInput {
   allEstimates: EstimateFieldsAfterCleaningFieldNamesStep[];
+  allStudies: StudyFieldsAfterCleaningFieldNamesStep[];
   vaccinationData: StructuredVaccinationDataAfterCleaningFieldNamesStep;
   positiveCaseData: StructuredPositiveCaseDataAfterCleaningFieldNamesStep;
 }
 
 interface RemoveRecordsThatAreFlaggedNotToSaveOutput {
   allEstimates: EstimateFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep[];
+  allStudies: StudyFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep[];
   vaccinationData: StructuredVaccinationDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep;
   positiveCaseData: StructuredPositiveCaseDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep;
 }
@@ -26,6 +30,7 @@ export const removeRecordsThatAreFlaggedNotToSave = (
     allEstimates: input.allEstimates.filter(
       (estimate) => estimate.includedInETL !== 0
     ),
+    allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
   };

--- a/src/etl/sars-cov-2/steps/transform-into-format-for-database-step.ts
+++ b/src/etl/sars-cov-2/steps/transform-into-format-for-database-step.ts
@@ -3,20 +3,24 @@ import { SarsCov2EstimateDocument } from "../../../storage/types.js";
 import { 
   EstimateFieldsAfterAddingPositiveCaseDataStep,
   StructuredPositiveCaseDataAfterAddingPositiveCaseDataStep,
-  StructuredVaccinationDataAfterAddingPositiveCaseDataStep
+  StructuredVaccinationDataAfterAddingPositiveCaseDataStep,
+  StudyFieldsAfterAddingPositiveCaseDataStep
 } from "./add-positive-case-data-to-estimate-step.js";
 
+export type StudyFieldsAfterTransformingFormatForDatabaseStep = StudyFieldsAfterAddingPositiveCaseDataStep;
 export type StructuredVaccinationDataAfterTransformingFormatForDatabaseStep = StructuredVaccinationDataAfterAddingPositiveCaseDataStep;
 export type StructuredPositiveCaseDataAfterTransformingFormatForDatabaseStep = StructuredPositiveCaseDataAfterAddingPositiveCaseDataStep;
 
 interface TransformIntoFormatForDatabaseStepInput {
   allEstimates: EstimateFieldsAfterAddingPositiveCaseDataStep[];
+  allStudies: StudyFieldsAfterAddingPositiveCaseDataStep[];
   vaccinationData: StructuredVaccinationDataAfterAddingPositiveCaseDataStep;
   positiveCaseData: StructuredPositiveCaseDataAfterAddingPositiveCaseDataStep;
 }
 
 interface TransformIntoFormatForDatabaseStepOutput {
   allEstimates: SarsCov2EstimateDocument[];
+  allStudies: StudyFieldsAfterTransformingFormatForDatabaseStep[];
   vaccinationData: StructuredVaccinationDataAfterTransformingFormatForDatabaseStep;
   positiveCaseData: StructuredPositiveCaseDataAfterTransformingFormatForDatabaseStep;
 }
@@ -43,6 +47,7 @@ export const transformIntoFormatForDatabaseStep = (
       riskOfBias: estimate.riskOfBias,
       ageGroup: estimate.ageGroup,
       sex: estimate.sex,
+      studyName: estimate.studyName,
       sourceType: estimate.sourceType,
       populationGroup: estimate.populationGroup,
       latitude: estimate.latitude,
@@ -67,6 +72,7 @@ export const transformIntoFormatForDatabaseStep = (
       createdAt: createdAtForAllRecords,
       updatedAt: updatedAtForAllRecords,
     })),
+    allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
   };

--- a/src/etl/sars-cov-2/steps/transform-not-reported-values-to-undefined-step.ts
+++ b/src/etl/sars-cov-2/steps/transform-not-reported-values-to-undefined-step.ts
@@ -1,19 +1,23 @@
 import { isArrayOfUnknownType } from "../../../lib/lib.js";
-import { EstimateFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep, StructuredPositiveCaseDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep, StructuredVaccinationDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep } from "./filter-studies-that-do-not-meet-data-structure-requirements.js";
+import { EstimateFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep, StructuredPositiveCaseDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep, StructuredVaccinationDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep, StudyFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep } from "./filter-studies-that-do-not-meet-data-structure-requirements.js";
 
 export type EstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep =
   EstimateFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep;
+export type StudyFieldsAfterTransformingNotReportedValuesToUndefinedStep =
+  StudyFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep;
 export type StructuredVaccinationDataAfterTransformingNotReportedValuesToUndefinedStep = StructuredVaccinationDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep;
 export type StructuredPositiveCaseDataAfterTransformingNotReportedValuesToUndefinedStep = StructuredPositiveCaseDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep;
 
 interface TransformNotReportedValuesToUndefinedStepInput {
   allEstimates: EstimateFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep[];
+  allStudies: StudyFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep[]
   vaccinationData: StructuredVaccinationDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep;
   positiveCaseData: StructuredPositiveCaseDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep;
 }
 
 interface TransformNotReportedValuesToUndefinedStepOutput {
   allEstimates: EstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
+  allStudies: StudyFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
   vaccinationData: StructuredVaccinationDataAfterTransformingNotReportedValuesToUndefinedStep;
   positiveCaseData: StructuredPositiveCaseDataAfterTransformingNotReportedValuesToUndefinedStep;
 }
@@ -57,6 +61,7 @@ export const transformNotReportedValuesToUndefinedStep = (
           })
         ) as EstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep
     ),
+    allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
   };

--- a/src/etl/sars-cov-2/types.ts
+++ b/src/etl/sars-cov-2/types.ts
@@ -1,5 +1,3 @@
-import { ThreeLetterIsoCountryCode } from "../../lib/geocoding-api/country-codes";
-
 export interface AirtableError {
   error: unknown;
 };
@@ -33,6 +31,12 @@ export interface AirtableSarsCov2EstimateFields {
   "Grade of Estimate Scope": string | null;
   "Sampling End Date": string | null;
   "Sampling Start Date": string | null;
+  "Rapid Review: Study": Array<string | null | AirtableError>;
+}
+
+export interface AirtableSarsCov2StudyFields {
+  id: string;
+  "Source Name (from Rapid Review: Source)": Array<string | null | AirtableError>;
 }
 
 export type StructuredVaccinationData = Array<{

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -74,6 +74,7 @@ export interface SarsCov2EstimateDocument {
   testType: string[];
   ageGroup: string | undefined;
   sex: string | undefined;
+  studyName: string;
   sourceType: string | undefined;
   populationGroup: string | undefined;
   latitude: number;


### PR DESCRIPTION
Added study name to the SarsCov2 estimates. One step in resolving https://github.com/serotracker/dashboard/issues/222. I basically need this field because I need to be able to figure out how many unique studies are in the entire SC2 dataset for one of the modals on the map.

I realize I also forgot to include `scope` on both the filter options and the estimates so I've introduced that field on the API here.