### PR TITLE
Made Mapbox Geocoding API cache more efficient

### DIFF
--- a/src/etl/arbo/index.ts
+++ b/src/etl/arbo/index.ts
@@ -56,6 +56,7 @@ const runEtlMain = async () => {
       {
         allEstimates: allEstimatesUnformatted,
         allSources: allSourcesUnformatted,
+        mongoClient
       },
       etlStep(cleanFieldNamesAndRemoveUnusedFieldsStep),
       etlStep(cleanSingleElementArrayFieldsStep),

--- a/src/etl/arbo/steps/add-country-and-region-information-step.ts
+++ b/src/etl/arbo/steps/add-country-and-region-information-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import {
   AirtableEstimateFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep,
   AirtableSourceFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep,
@@ -17,11 +18,13 @@ export type AirtableSourceFieldsAfterAddingCountryAndRegionInformationStep =
 interface AddCountryAndRegionInformationStepInput {
   allEstimates: AirtableEstimateFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep[];
   allSources: AirtableSourceFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep[];
+  mongoClient: MongoClient;
 }
 
 interface AddCountryAndRegionInformationStepOutput {
   allEstimates: AirtableEstimateFieldsAfterAddingCountryAndRegionInformationStep[];
   allSources: AirtableSourceFieldsAfterAddingCountryAndRegionInformationStep[];
+  mongoClient: MongoClient;
 }
 
 export const addCountryAndRegionInformationStep = (
@@ -53,5 +56,6 @@ export const addCountryAndRegionInformationStep = (
       })
       .filter(<T>(estimate: T | undefined): estimate is T => !!estimate),
     allSources: allSources,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/assert-mandatory-fields-are-present-step.ts
+++ b/src/etl/arbo/steps/assert-mandatory-fields-are-present-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import { AirtableEstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep, AirtableSourceFieldsAfterTransformingNotReportedValuesToUndefinedStep } from "./transform-not-reported-values-to-undefined-step.js";
 
 export type AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep =
@@ -15,11 +16,13 @@ export type AirtableSourceFieldsAfterAssertingMandatoryFieldsArePresentStep =
 interface AssertMandatoryFieldsArePresentStepInput {
   allEstimates: AirtableEstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
   allSources: AirtableSourceFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
+  mongoClient: MongoClient;
 }
 
 interface AssertMandatoryFieldsAreStepOutput {
   allEstimates: AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep[];
   allSources: AirtableSourceFieldsAfterAssertingMandatoryFieldsArePresentStep[];
+  mongoClient: MongoClient;
 }
 
 export const assertMandatoryFieldsArePresentStep = (
@@ -34,5 +37,6 @@ export const assertMandatoryFieldsArePresentStep = (
       return !!estimate.country && !!estimate.pathogen;
     }),
     allSources: allSources,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/clean-field-names-and-remove-unused-fields-step.ts
+++ b/src/etl/arbo/steps/clean-field-names-and-remove-unused-fields-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import { AirtableEstimateFields, AirtableSourceFields } from "../types.js";
 
 export interface AirtableEstimateFieldsAfterCleaningFieldNamesAndRemoveUnusedFieldsStep {
@@ -44,11 +45,13 @@ export interface AirtableSourceFieldsCleaningFieldNamesAndRemoveUnusedFieldsStep
 interface CleanFieldNamesAndRemoveUnusedFieldsStepInput {
   allEstimates: AirtableEstimateFields[];
   allSources: AirtableSourceFields[];
+  mongoClient: MongoClient;
 }
 
 interface CleanFieldNamesAndRemoveUnusedFieldsStepOutput {
   allEstimates: AirtableEstimateFieldsAfterCleaningFieldNamesAndRemoveUnusedFieldsStep[];
   allSources: AirtableSourceFieldsCleaningFieldNamesAndRemoveUnusedFieldsStep[];
+  mongoClient: MongoClient;
 }
 
 export const cleanFieldNamesAndRemoveUnusedFieldsStep = (
@@ -98,5 +101,6 @@ export const cleanFieldNamesAndRemoveUnusedFieldsStep = (
       id: source["id"],
       sourceSheetName: source["Source Title"],
     })),
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/clean-field-names-and-remove-unused-fields-step.ts
+++ b/src/etl/arbo/steps/clean-field-names-and-remove-unused-fields-step.ts
@@ -85,7 +85,7 @@ export const cleanFieldNamesAndRemoveUnusedFieldsStep = (
       seroprevalenceStudy95CIUpper: estimate["Seroprevalence 95% CI Upper"],
       seroprevalenceCalculated95CILower: estimate["Seroprevalence 95% CI Lower (formula)"],
       seroprevalenceCalculated95CIUpper: estimate["Seroprevalence 95% CI Upper (formula)"],
-      country: estimate["Country"],
+      country: estimate["Country archive"],
       state: estimate["State"],
       city: estimate["City"],
       url: estimate["URL"],

--- a/src/etl/arbo/steps/clean-single-element-array-fields-step.ts
+++ b/src/etl/arbo/steps/clean-single-element-array-fields-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import {
   AirtableEstimateFieldsAfterCleaningFieldNamesAndRemoveUnusedFieldsStep,
   AirtableSourceFieldsCleaningFieldNamesAndRemoveUnusedFieldsStep,
@@ -18,11 +19,13 @@ export type AirtableSourceFieldsAfterCleaningSingleElementArrayFieldsStep =
 interface CleanSingleElementArrayFieldsStepInput {
   allEstimates: AirtableEstimateFieldsAfterCleaningFieldNamesAndRemoveUnusedFieldsStep[];
   allSources: AirtableSourceFieldsCleaningFieldNamesAndRemoveUnusedFieldsStep[];
+  mongoClient: MongoClient;
 }
 
 interface CleanSingleElementArrayFieldsStepOutput {
   allEstimates: AirtableEstimateFieldsAfterCleaningSingleElementArrayFieldsStep[];
   allSources: AirtableSourceFieldsAfterCleaningSingleElementArrayFieldsStep[];
+  mongoClient: MongoClient;
 }
 
 export const cleanSingleElementArrayFieldsStep = (
@@ -42,5 +45,6 @@ export const cleanSingleElementArrayFieldsStep = (
       };
     }),
     allSources: allSources,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/jitter-pin-lat-lng-step.ts
+++ b/src/etl/arbo/steps/jitter-pin-lat-lng-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import { AirtableEstimateFieldsAfterLatLngGenerationStep, AirtableSourceFieldsAfterLatLngGenerationStep } from "./lat-lng-generation-step.js";
 
 export type AirtableEstimateFieldsAfterJitteringPinLatLngStep = AirtableEstimateFieldsAfterLatLngGenerationStep;
@@ -21,11 +22,13 @@ const jitterNumberValueByAmount = (input: JitterNumberValueByAmountInput): numbe
 interface JitterPinLatLngStepInput {
   allEstimates: AirtableEstimateFieldsAfterLatLngGenerationStep[];
   allSources: AirtableSourceFieldsAfterLatLngGenerationStep[];
+  mongoClient: MongoClient;
 }
 
 interface JitterPinLatLngStepOutput {
   allEstimates: AirtableEstimateFieldsAfterJitteringPinLatLngStep[];
   allSources: AirtableSourceFieldsAfterJitteringPinLatLngStep[];
+  mongoClient: MongoClient;
 }
 
 export const jitterPinLatLngStep = (
@@ -43,5 +46,6 @@ export const jitterPinLatLngStep = (
       longitude: jitterNumberValueByAmount({value: estimate.longitude, jitterAmount: maximumPinJitterMagnitude}),
     })),
     allSources: allSources,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/lat-lng-generation-step.ts
+++ b/src/etl/arbo/steps/lat-lng-generation-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import { writeFileSync } from 'fs';
 import { getLatitude, getLongitude } from "../../../lib/geocoding-api/coordinate-helpers.js";
 import { Point } from "../../../lib/geocoding-api/geocoding-api-client-types.js";
@@ -19,11 +20,13 @@ export type AirtableSourceFieldsAfterLatLngGenerationStep =
 interface LatLngGenerationStepInput {
   allEstimates: AirtableEstimateFieldsAfterMergingEstimatesAndSourcesStep[];
   allSources: AirtableSourceFieldsAfterMergingEstimatesAndSourcesStep[];
+  mongoClient: MongoClient;
 }
 
 interface LatLngGenerationStepOutput {
   allEstimates: AirtableEstimateFieldsAfterLatLngGenerationStep[];
   allSources: AirtableSourceFieldsAfterLatLngGenerationStep[];
+  mongoClient: MongoClient;
 }
 
 export const latLngGenerationStep = async(
@@ -53,7 +56,8 @@ export const latLngGenerationStep = async(
         city: estimate.city,
         state: estimate.state,
         country: estimate.country,
-        geocodingApiRequestReportFileName
+        geocodingApiRequestReportFileName,
+        mongoClient: input.mongoClient
       })
     }
 
@@ -69,5 +73,6 @@ export const latLngGenerationStep = async(
   return {
     allEstimates: estimatesWithLatitudesAndLongitudes,
     allSources: allSources,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/merge-estimates-and-sources-step.ts
+++ b/src/etl/arbo/steps/merge-estimates-and-sources-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import {
   AirtableEstimateFieldsAfterAddingCountryAndRegionInformationStep,
   AirtableSourceFieldsAfterAddingCountryAndRegionInformationStep
@@ -14,11 +15,13 @@ export type AirtableSourceFieldsAfterMergingEstimatesAndSourcesStep =
 interface MergeEstimatesAndSourcesStepInput {
   allEstimates: AirtableEstimateFieldsAfterAddingCountryAndRegionInformationStep[];
   allSources: AirtableSourceFieldsAfterAddingCountryAndRegionInformationStep[];
+  mongoClient: MongoClient;
 }
 
 interface MergeEstimatesAndSourcesStepOutput {
   allEstimates: AirtableEstimateFieldsAfterMergingEstimatesAndSourcesStep[];
   allSources: AirtableSourceFieldsAfterMergingEstimatesAndSourcesStep[];
+  mongoClient: MongoClient;
 }
 
 export const mergeEstimatesAndSourcesStep = (
@@ -40,5 +43,6 @@ export const mergeEstimatesAndSourcesStep = (
       };
     }),
     allSources: allSources,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/parse-dates-step.ts
+++ b/src/etl/arbo/steps/parse-dates-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import { parse } from "date-fns";
 import { AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep, AirtableSourceFieldsAfterAssertingMandatoryFieldsArePresentStep } from "./assert-mandatory-fields-are-present-step.js";
 
@@ -15,11 +16,13 @@ export type AirtableSourceFieldsAfterParsingDatesStep =
 interface ParseDatesStepInput {
   allEstimates: AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep[];
   allSources: AirtableSourceFieldsAfterParsingDatesStep[];
+  mongoClient: MongoClient;
 }
 
 interface ParseDatesStepOutput {
   allEstimates: AirtableEstimateFieldsAfterParsingDatesStep[];
   allSources: AirtableSourceFieldsAfterParsingDatesStep[];
+  mongoClient: MongoClient;
 }
 
 export const parseDatesStep = (
@@ -38,5 +41,6 @@ export const parseDatesStep = (
       };
     }),
     allSources: allSources,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/remove-estimates-with-low-sample-size-step.ts
+++ b/src/etl/arbo/steps/remove-estimates-with-low-sample-size-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import {
   AirtableEstimateFieldsAfterParsingDatesStep,
   AirtableSourceFieldsAfterParsingDatesStep,
@@ -12,11 +13,13 @@ export type AirtableSourceFieldsAfterRemovingEstimatesWithLowSampleSizeStep =
 interface RemoveEstimatesWithLowSampleSizeStepInput {
   allEstimates: AirtableEstimateFieldsAfterParsingDatesStep[];
   allSources: AirtableSourceFieldsAfterParsingDatesStep[];
+  mongoClient: MongoClient;
 }
 
 interface RemoveEstimatesWithLowSampleSizeStepOutput {
   allEstimates: AirtableEstimateFieldsAfterRemovingEstimatesWithLowSampleSizeStep[];
   allSources: AirtableSourceFieldsAfterRemovingEstimatesWithLowSampleSizeStep[];
+  mongoClient: MongoClient;
 }
 
 export const removeEstimatesWithLowSampleSizeStep = (
@@ -41,5 +44,6 @@ export const removeEstimatesWithLowSampleSizeStep = (
       return true;
     }),
     allSources: allSources,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/remove-records-that-are-flagged-to-not-save-step.ts
+++ b/src/etl/arbo/steps/remove-records-that-are-flagged-to-not-save-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import {
   AirtableEstimateFieldsAfterRemovingEstimatesWithLowSampleSizeStep,
   AirtableSourceFieldsAfterRemovingEstimatesWithLowSampleSizeStep,
@@ -14,11 +15,13 @@ export type AirtableSourceFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep 
 interface RemoveRecordsThatAreFlaggedToNotSaveStepInput {
   allEstimates: AirtableEstimateFieldsAfterRemovingEstimatesWithLowSampleSizeStep[];
   allSources: AirtableSourceFieldsAfterRemovingEstimatesWithLowSampleSizeStep[];
+  mongoClient: MongoClient;
 }
 
 interface RemoveRecordsThatAreFlaggedToNotSaveStepOutput {
   allEstimates: AirtableEstimateFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep[];
   allSources: AirtableSourceFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep[];
+  mongoClient: MongoClient;
 }
 
 export const removeRecordsThatAreFlaggedToNotSaveStep = (
@@ -33,5 +36,6 @@ export const removeRecordsThatAreFlaggedToNotSaveStep = (
       estimate.includeInEtl === 1
     ),
     allSources: allSources,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/transform-into-format-for-database-step.ts
+++ b/src/etl/arbo/steps/transform-into-format-for-database-step.ts
@@ -1,4 +1,4 @@
-import { ObjectId } from "mongodb";
+import { ObjectId, MongoClient } from "mongodb";
 import { ArbovirusEstimateDocument } from "../../../storage/types.js";
 import {
   AirtableEstimateFieldsAfterJitteringPinLatLngStep,
@@ -12,11 +12,13 @@ export type AirtableSourceFieldsAfterTransformingIntoFormatForDatabaseStep = Air
 interface TransformIntoFormatForDatabaseStepInput {
   allEstimates: AirtableEstimateFieldsAfterJitteringPinLatLngStep[];
   allSources: AirtableSourceFieldsAfterJitteringPinLatLngStep[];
+  mongoClient: MongoClient;
 }
 
 interface TransformIntoFormatForDatabaseStepOutput {
   allEstimates: ArbovirusEstimateDocument[];
   allSources: AirtableSourceFieldsAfterTransformingIntoFormatForDatabaseStep[];
+  mongoClient: MongoClient;
 }
 
 export const transformIntoFormatForDatabaseStep = (
@@ -73,5 +75,6 @@ export const transformIntoFormatForDatabaseStep = (
       updatedAt: updatedAtForAllRecords
     })),
     allSources: allSources,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/transform-not-reported-values-to-undefined-step.ts
+++ b/src/etl/arbo/steps/transform-not-reported-values-to-undefined-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import { isArrayOfUnknownType } from "../../../lib/lib.js";
 import {
   AirtableEstimateFieldsAfterCleaningSingleElementArrayFieldsStep,
@@ -13,11 +14,13 @@ export type AirtableSourceFieldsAfterTransformingNotReportedValuesToUndefinedSte
 interface TransformNotReportedValuesToUndefinedStepInput {
   allEstimates: AirtableEstimateFieldsAfterCleaningSingleElementArrayFieldsStep[];
   allSources: AirtableSourceFieldsAfterCleaningSingleElementArrayFieldsStep[];
+  mongoClient: MongoClient;
 }
 
 interface TransformNotReportedValuesToUndefinedStepOutput {
   allEstimates: AirtableEstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
   allSources: AirtableSourceFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
+  mongoClient: MongoClient;
 }
 
 enum NotReportedValue {
@@ -60,5 +63,6 @@ export const transformNotReportedValuesToUndefinedStep = (
         ) as AirtableEstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep
     ),
     allSources: allSources,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/sars-cov-2/index.ts
+++ b/src/etl/sars-cov-2/index.ts
@@ -63,6 +63,7 @@ const runEtlMain = async () => {
       allStudies: allStudiesUnformatted,
       vaccinationData: undefined,
       positiveCaseData: undefined,
+      mongoClient
     },
     asyncEtlStep(fetchVaccinationDataStep),
     asyncEtlStep(fetchPositiveCaseDataStep),

--- a/src/etl/sars-cov-2/steps/add-country-and-region-information-step.ts
+++ b/src/etl/sars-cov-2/steps/add-country-and-region-information-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import { EstimateFieldsAfterParsingDatesStep, StructuredPositiveCaseDataAfterParsingDatesStep, StructuredVaccinationDataAfterParsingDatesStep, StudyFieldsAfterParsingDatesStep } from "./parse-dates-step.js";
 import { UNRegion, getUNRegionFromAlphaTwoCode } from "../../../lib/un-regions.js";
 import { WHORegion, getWHORegionFromAlphaTwoCode } from "../../../lib/who-regions.js";
@@ -20,6 +21,7 @@ interface AddCountryAndRegionInformationStepInput {
   allStudies: StudyFieldsAfterParsingDatesStep[];
   vaccinationData: StructuredVaccinationDataAfterParsingDatesStep;
   positiveCaseData: StructuredPositiveCaseDataAfterParsingDatesStep;
+  mongoClient: MongoClient;
 }
 
 interface AddCountryAndRegionInformationStepOutput {
@@ -27,6 +29,7 @@ interface AddCountryAndRegionInformationStepOutput {
   allStudies: StudyFieldsAfterAddingCountryAndRegionInformationStep[];
   vaccinationData: StructuredVaccinationDataAfterAddingCountryAndRegionInformationStep;
   positiveCaseData: StructuredPositiveCaseDataAfterAddingCountryAndRegionInformationStep;
+  mongoClient: MongoClient;
 }
 
 export const addCountryAndRegionInformationStep = (input: AddCountryAndRegionInformationStepInput): AddCountryAndRegionInformationStepOutput => {
@@ -63,5 +66,6 @@ export const addCountryAndRegionInformationStep = (input: AddCountryAndRegionInf
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
+    mongoClient: input.mongoClient
   };
 }

--- a/src/etl/sars-cov-2/steps/add-positive-case-data-to-estimate-step.ts
+++ b/src/etl/sars-cov-2/steps/add-positive-case-data-to-estimate-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import { EstimateFieldsAfterAddingVaccinationDataStep, StructuredPositiveCaseDataAfterAddingVaccinationDataStep, StructuredVaccinationDataAfterAddingVaccinationDataStep, StudyFieldsAfterAddingVaccinationDataStep } from "./add-vaccination-data-to-estimate-step";
 
 export type EstimateFieldsAfterAddingPositiveCaseDataStep =
@@ -16,6 +17,7 @@ interface AddPositiveCaseDataToEstimateStepInput {
   allStudies: StudyFieldsAfterAddingVaccinationDataStep[];
   vaccinationData: StructuredVaccinationDataAfterAddingVaccinationDataStep;
   positiveCaseData: StructuredPositiveCaseDataAfterAddingVaccinationDataStep;
+  mongoClient: MongoClient;
 }
 
 interface AddPositiveCaseDataToEstimateStepOutput {
@@ -23,6 +25,7 @@ interface AddPositiveCaseDataToEstimateStepOutput {
   allStudies: StudyFieldsAfterAddingPositiveCaseDataStep[];
   vaccinationData: StructuredVaccinationDataAfterAddingPositiveCaseDataStep;
   positiveCaseData: StructuredPositiveCaseDataAfterAddingPositiveCaseDataStep;
+  mongoClient: MongoClient;
 }
 
 export const addPositiveCaseDataToEstimateStep = (
@@ -44,5 +47,6 @@ export const addPositiveCaseDataToEstimateStep = (
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/sars-cov-2/steps/add-vaccination-data-to-estimate-step.ts
+++ b/src/etl/sars-cov-2/steps/add-vaccination-data-to-estimate-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import {
   EstimateFieldsAfterJitteringPinLatLngStep,
   StructuredPositiveCaseDataAfterJitteringPinLatLngStep,
@@ -21,6 +22,7 @@ interface AddVaccinationDataToEstimateStepInput {
   allStudies: StudyFieldsAfterJitteringPinLatLngStep[];
   vaccinationData: StructuredVaccinationDataAfterJitteringPinLatLngStep;
   positiveCaseData: StructuredPositiveCaseDataAfterJitteringPinLatLngStep;
+  mongoClient: MongoClient;
 }
 
 interface AddVaccinationDataToEstimateStepOutput {
@@ -28,6 +30,7 @@ interface AddVaccinationDataToEstimateStepOutput {
   allStudies: StudyFieldsAfterAddingVaccinationDataStep[];
   vaccinationData: StructuredVaccinationDataAfterAddingVaccinationDataStep;
   positiveCaseData: StructuredPositiveCaseDataAfterAddingVaccinationDataStep;
+  mongoClient: MongoClient;
 }
 
 export const addVaccinationDataToEstimateStep = (
@@ -59,5 +62,6 @@ export const addVaccinationDataToEstimateStep = (
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/sars-cov-2/steps/clean-field-names-and-remove-unused-fields-step.ts
+++ b/src/etl/sars-cov-2/steps/clean-field-names-and-remove-unused-fields-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import { isArrayOfUnknownType } from "../../../lib/lib.js";
 import { EstimateFieldsAfterValidatingFieldSetFromAirtableStep, StructuredPositiveCaseDataAfterValidatingFieldSetFromAirtableStep, StructuredVaccinationDataAfterValidatingFieldSetFromAirtableStep, StudyFieldsAfterValidatingFieldSetFromAirtableStep } from "./validate-field-set-from-airtable-step.js";
 import { isAirtableError, AirtableError } from "../types.js";
@@ -36,6 +37,7 @@ interface CleanFieldNamesAndRemoveUnusedFieldsStepInput {
   allStudies: StudyFieldsAfterValidatingFieldSetFromAirtableStep[];
   vaccinationData: StructuredVaccinationDataAfterValidatingFieldSetFromAirtableStep;
   positiveCaseData: StructuredPositiveCaseDataAfterValidatingFieldSetFromAirtableStep;
+  mongoClient: MongoClient;
 }
 
 interface CleanFieldNamesAndRemoveUnusedFieldsStepOutput {
@@ -43,6 +45,7 @@ interface CleanFieldNamesAndRemoveUnusedFieldsStepOutput {
   allStudies: StudyFieldsAfterCleaningFieldNamesStep[];
   vaccinationData: StructuredVaccinationDataAfterCleaningFieldNamesStep;
   positiveCaseData: StructuredPositiveCaseDataAfterCleaningFieldNamesStep;
+  mongoClient: MongoClient;
 }
 
 interface CleanArrayFieldToSingleValueInput<
@@ -189,5 +192,6 @@ export const cleanFieldNamesAndRemoveUnusedFieldsStep = (
     })),
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/sars-cov-2/steps/combine-estimates-and-studies-step.ts
+++ b/src/etl/sars-cov-2/steps/combine-estimates-and-studies-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import {
   EstimateFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep,
   StructuredPositiveCaseDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep,
@@ -17,6 +18,7 @@ interface CombineEstimatesAndStudiesInput {
   allStudies: StudyFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep[];
   vaccinationData: StructuredVaccinationDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep;
   positiveCaseData: StructuredPositiveCaseDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep;
+  mongoClient: MongoClient;
 }
 
 interface CombineEstimatesAndStudiesOutput {
@@ -24,6 +26,7 @@ interface CombineEstimatesAndStudiesOutput {
   allStudies: StudyFieldsAfterCombiningEstimatesAndStudiesStep[];
   vaccinationData: StructuredVaccinationDataAfterAfterCombiningEstimatesAndStudiesStep;
   positiveCaseData: StructuredPositiveCaseDataAfterAfterCombiningEstimatesAndStudiesStep;
+  mongoClient: MongoClient;
 }
 
 export const combineEstimatesAndStudies = (
@@ -52,5 +55,6 @@ export const combineEstimatesAndStudies = (
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/sars-cov-2/steps/fetch-positive-case-data-step.ts
+++ b/src/etl/sars-cov-2/steps/fetch-positive-case-data-step.ts
@@ -1,4 +1,5 @@
 import { request } from "undici";
+import { MongoClient } from "mongodb";
 import { StructuredPositiveCaseData } from "../types";
 import { EstimateFieldsAfterFetchingVaccinationDataStep, StructuredPositiveCaseDataAfterFetchingVaccinationDataStep, StructuredVaccinationDataAfterFetchingVaccinationDataStep, StudyFieldsAfterFetchingVaccinationDataStep } from "./fetch-vaccination-data-step";
 import { TwoLetterIsoCountryCode } from "../../../lib/geocoding-api/country-codes";
@@ -14,6 +15,7 @@ interface FetchPositiveCaseDataStepInput {
   allStudies: StudyFieldsAfterFetchingVaccinationDataStep[];
   vaccinationData: StructuredVaccinationDataAfterFetchingVaccinationDataStep;
   positiveCaseData: StructuredPositiveCaseDataAfterFetchingVaccinationDataStep;
+  mongoClient: MongoClient;
 }
 
 interface FetchPositiveCaseDataStepOutput {
@@ -21,6 +23,7 @@ interface FetchPositiveCaseDataStepOutput {
   allStudies: StudyFieldsAfterFetchingPositiveCaseDataStep[];
   vaccinationData: StructuredVaccinationDataAfterFetchingPositiveCaseDataStep;
   positiveCaseData: StructuredPositiveCaseDataAfterFetchingPositiveCaseDataStep;
+  mongoClient: MongoClient;
 }
 
 const countryNamesInCSVToTwoLetterCountryCode: Record<string, TwoLetterIsoCountryCode | undefined> = {
@@ -303,5 +306,6 @@ export const fetchPositiveCaseDataStep = async(
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: formattedPositiveCaseData,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/sars-cov-2/steps/fetch-vaccination-data-step.ts
+++ b/src/etl/sars-cov-2/steps/fetch-vaccination-data-step.ts
@@ -1,4 +1,5 @@
 import { FieldSet } from "airtable";
+import { MongoClient } from "mongodb";
 import { StructuredVaccinationData } from "../types";
 import { request } from "undici";
 import { groupByArray } from "../../../lib/lib.js";
@@ -15,6 +16,7 @@ interface FetchVaccinationDataStepInput {
   allStudies: FieldSet[];
   vaccinationData: undefined;
   positiveCaseData: undefined;
+  mongoClient: MongoClient;
 }
 
 interface FetchVaccinationDataStepOutput {
@@ -22,6 +24,7 @@ interface FetchVaccinationDataStepOutput {
   allStudies: StudyFieldsAfterFetchingVaccinationDataStep[];
   vaccinationData: StructuredVaccinationDataAfterFetchingVaccinationDataStep;
   positiveCaseData: StructuredPositiveCaseDataAfterFetchingVaccinationDataStep;
+  mongoClient: MongoClient;
 }
 
 export const fetchVaccinationDataStep = async (
@@ -80,5 +83,6 @@ export const fetchVaccinationDataStep = async (
     allStudies: input.allStudies,
     vaccinationData: formattedVaccinationData,
     positiveCaseData: input.positiveCaseData,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/sars-cov-2/steps/filter-studies-that-do-not-meet-data-structure-requirements.ts
+++ b/src/etl/sars-cov-2/steps/filter-studies-that-do-not-meet-data-structure-requirements.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import {
   EstimateFieldsAfterCombiningEstimatesAndStudiesStep,
   StructuredPositiveCaseDataAfterAfterCombiningEstimatesAndStudiesStep,
@@ -22,6 +23,7 @@ interface FilterStudiesThatDoNotMeetDataStructureRequirementsInput {
   allStudies: StudyFieldsAfterCombiningEstimatesAndStudiesStep[];
   vaccinationData: StructuredVaccinationDataAfterAfterCombiningEstimatesAndStudiesStep;
   positiveCaseData: StructuredPositiveCaseDataAfterAfterCombiningEstimatesAndStudiesStep;
+  mongoClient: MongoClient;
 }
 
 interface FilterStudiesThatDoNotMeetDataStructureRequirementsOutput {
@@ -29,6 +31,7 @@ interface FilterStudiesThatDoNotMeetDataStructureRequirementsOutput {
   allStudies: StudyFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep[];
   vaccinationData: StructuredVaccinationDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep;
   positiveCaseData: StructuredPositiveCaseDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep;
+  mongoClient: MongoClient;
 }
 
 export const filterStudiesThatDoNotMeetDataStructureRequirement = (
@@ -48,5 +51,6 @@ export const filterStudiesThatDoNotMeetDataStructureRequirement = (
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/sars-cov-2/steps/jitter-pin-lat-lng-step.ts
+++ b/src/etl/sars-cov-2/steps/jitter-pin-lat-lng-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import { EstimateFieldsAfterLatLngGenerationStep, StructuredPositiveCaseDataAfterLatLngGenerationStep, StructuredVaccinationDataAfterLatLngGenerationStep, StudyFieldsAfterLatLngGenerationStep } from "./lat-lng-generation-step.js";
 
 export type EstimateFieldsAfterJitteringPinLatLngStep =
@@ -30,6 +31,7 @@ interface JitterPinLatLngStepInput {
   allStudies: StudyFieldsAfterLatLngGenerationStep[];
   vaccinationData: StructuredVaccinationDataAfterLatLngGenerationStep;
   positiveCaseData: StructuredPositiveCaseDataAfterLatLngGenerationStep;
+  mongoClient: MongoClient;
 }
 
 interface JitterPinLatLngStepOutput {
@@ -37,6 +39,7 @@ interface JitterPinLatLngStepOutput {
   allStudies: StudyFieldsAfterJitteringPinLatLngStep[];
   vaccinationData: StructuredVaccinationDataAfterJitteringPinLatLngStep;
   positiveCaseData: StructuredPositiveCaseDataAfterJitteringPinLatLngStep;
+  mongoClient: MongoClient;
 }
 
 export const jitterPinLatLngStep = (
@@ -64,5 +67,6 @@ export const jitterPinLatLngStep = (
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/sars-cov-2/steps/lat-lng-generation-step.ts
+++ b/src/etl/sars-cov-2/steps/lat-lng-generation-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import { writeFileSync } from "fs";
 import { EstimateFieldsAfterAddingCountryAndRegionInformationStep, StructuredPositiveCaseDataAfterAddingCountryAndRegionInformationStep, StructuredVaccinationDataAfterAddingCountryAndRegionInformationStep, StudyFieldsAfterAddingCountryAndRegionInformationStep } from "./add-country-and-region-information-step";
 import { Point } from "../../../lib/geocoding-api/geocoding-api-client-types.js";
@@ -17,6 +18,7 @@ interface LatLngGenerationStepInput {
   allStudies: StudyFieldsAfterAddingCountryAndRegionInformationStep[];
   vaccinationData: StructuredVaccinationDataAfterAddingCountryAndRegionInformationStep;
   positiveCaseData: StructuredPositiveCaseDataAfterAddingCountryAndRegionInformationStep;
+  mongoClient: MongoClient;
 }
 
 interface LatLngGenerationStepOutput {
@@ -24,6 +26,7 @@ interface LatLngGenerationStepOutput {
   allStudies: StudyFieldsAfterLatLngGenerationStep[];
   vaccinationData: StructuredVaccinationDataAfterLatLngGenerationStep;
   positiveCaseData: StructuredPositiveCaseDataAfterLatLngGenerationStep;
+  mongoClient: MongoClient;
 }
 
 export const latLngGenerationStep = async(
@@ -53,7 +56,8 @@ export const latLngGenerationStep = async(
         city: estimate.city,
         state: estimate.state,
         country: estimate.country,
-        geocodingApiRequestReportFileName
+        geocodingApiRequestReportFileName,
+        mongoClient: input.mongoClient
       })
     }
 
@@ -71,5 +75,6 @@ export const latLngGenerationStep = async(
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
+    mongoClient: input.mongoClient
   };
 }

--- a/src/etl/sars-cov-2/steps/parse-dates-step.ts
+++ b/src/etl/sars-cov-2/steps/parse-dates-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import { parse } from "date-fns";
 import { EstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep, StructuredPositiveCaseDataAfterTransformingNotReportedValuesToUndefinedStep, StructuredVaccinationDataAfterTransformingNotReportedValuesToUndefinedStep, StudyFieldsAfterTransformingNotReportedValuesToUndefinedStep } from "./transform-not-reported-values-to-undefined-step.js";
 
@@ -15,6 +16,7 @@ interface ParseDatesStepInput {
   allStudies: StudyFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
   vaccinationData: StructuredVaccinationDataAfterTransformingNotReportedValuesToUndefinedStep;
   positiveCaseData: StructuredPositiveCaseDataAfterTransformingNotReportedValuesToUndefinedStep;
+  mongoClient: MongoClient;
 }
 
 interface ParseDatesStepOutput {
@@ -22,6 +24,7 @@ interface ParseDatesStepOutput {
   allStudies: StudyFieldsAfterParsingDatesStep[];
   vaccinationData: StructuredVaccinationDataAfterParsingDatesStep;
   positiveCaseData: StructuredPositiveCaseDataAfterParsingDatesStep;
+  mongoClient: MongoClient;
 }
 
 export const parseDatesStep = (input: ParseDatesStepInput): ParseDatesStepOutput => {
@@ -45,5 +48,6 @@ export const parseDatesStep = (input: ParseDatesStepInput): ParseDatesStepOutput
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
+    mongoClient: input.mongoClient
   };
 }

--- a/src/etl/sars-cov-2/steps/remove-records-that-are-flagged-to-not-save-step.ts
+++ b/src/etl/sars-cov-2/steps/remove-records-that-are-flagged-to-not-save-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import { EstimateFieldsAfterCleaningFieldNamesStep, StructuredPositiveCaseDataAfterCleaningFieldNamesStep, StructuredVaccinationDataAfterCleaningFieldNamesStep, StudyFieldsAfterCleaningFieldNamesStep } from "./clean-field-names-and-remove-unused-fields-step.js";
 
 export type EstimateFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep =
@@ -12,6 +13,7 @@ interface RemoveRecordsThatAreFlaggedNotToSaveInput {
   allStudies: StudyFieldsAfterCleaningFieldNamesStep[];
   vaccinationData: StructuredVaccinationDataAfterCleaningFieldNamesStep;
   positiveCaseData: StructuredPositiveCaseDataAfterCleaningFieldNamesStep;
+  mongoClient: MongoClient;
 }
 
 interface RemoveRecordsThatAreFlaggedNotToSaveOutput {
@@ -19,6 +21,7 @@ interface RemoveRecordsThatAreFlaggedNotToSaveOutput {
   allStudies: StudyFieldsAfterRemovingRecordsThatAreFlaggedNotToSaveStep[];
   vaccinationData: StructuredVaccinationDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep;
   positiveCaseData: StructuredPositiveCaseDataAfterRemovingRecordsThatAreFlaggedNotToSaveStep;
+  mongoClient: MongoClient;
 }
 
 export const removeRecordsThatAreFlaggedNotToSave = (
@@ -33,5 +36,6 @@ export const removeRecordsThatAreFlaggedNotToSave = (
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/sars-cov-2/steps/transform-into-format-for-database-step.ts
+++ b/src/etl/sars-cov-2/steps/transform-into-format-for-database-step.ts
@@ -1,4 +1,4 @@
-import { ObjectId } from "mongodb";
+import { ObjectId, MongoClient } from "mongodb";
 import { SarsCov2EstimateDocument } from "../../../storage/types.js";
 import { 
   EstimateFieldsAfterAddingPositiveCaseDataStep,
@@ -16,6 +16,7 @@ interface TransformIntoFormatForDatabaseStepInput {
   allStudies: StudyFieldsAfterAddingPositiveCaseDataStep[];
   vaccinationData: StructuredVaccinationDataAfterAddingPositiveCaseDataStep;
   positiveCaseData: StructuredPositiveCaseDataAfterAddingPositiveCaseDataStep;
+  mongoClient: MongoClient;
 }
 
 interface TransformIntoFormatForDatabaseStepOutput {
@@ -23,6 +24,7 @@ interface TransformIntoFormatForDatabaseStepOutput {
   allStudies: StudyFieldsAfterTransformingFormatForDatabaseStep[];
   vaccinationData: StructuredVaccinationDataAfterTransformingFormatForDatabaseStep;
   positiveCaseData: StructuredPositiveCaseDataAfterTransformingFormatForDatabaseStep;
+  mongoClient: MongoClient;
 }
 
 export const transformIntoFormatForDatabaseStep = (
@@ -75,5 +77,6 @@ export const transformIntoFormatForDatabaseStep = (
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/sars-cov-2/steps/transform-not-reported-values-to-undefined-step.ts
+++ b/src/etl/sars-cov-2/steps/transform-not-reported-values-to-undefined-step.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import { isArrayOfUnknownType } from "../../../lib/lib.js";
 import { EstimateFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep, StructuredPositiveCaseDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep, StructuredVaccinationDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep, StudyFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep } from "./filter-studies-that-do-not-meet-data-structure-requirements.js";
 
@@ -13,6 +14,7 @@ interface TransformNotReportedValuesToUndefinedStepInput {
   allStudies: StudyFieldsAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep[]
   vaccinationData: StructuredVaccinationDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep;
   positiveCaseData: StructuredPositiveCaseDataAfterFilteringStudiesThatDoNotMeetDataStructureRequirementsStep;
+  mongoClient: MongoClient;
 }
 
 interface TransformNotReportedValuesToUndefinedStepOutput {
@@ -20,6 +22,7 @@ interface TransformNotReportedValuesToUndefinedStepOutput {
   allStudies: StudyFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
   vaccinationData: StructuredVaccinationDataAfterTransformingNotReportedValuesToUndefinedStep;
   positiveCaseData: StructuredPositiveCaseDataAfterTransformingNotReportedValuesToUndefinedStep;
+  mongoClient: MongoClient;
 }
 
 enum NotReportedValue {
@@ -64,5 +67,6 @@ export const transformNotReportedValuesToUndefinedStep = (
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/etl/sars-cov-2/steps/validate-field-set-from-airtable-step.ts
+++ b/src/etl/sars-cov-2/steps/validate-field-set-from-airtable-step.ts
@@ -1,5 +1,5 @@
-import { FieldSet } from "airtable";
 import { z } from "zod";
+import { MongoClient } from "mongodb";
 import { AirtableSarsCov2EstimateFields, AirtableSarsCov2StudyFields } from "../types.js";
 import { EstimateFieldsAfterFetchingPositiveCaseDataStep, StructuredPositiveCaseDataAfterFetchingPositiveCaseDataStep, StructuredVaccinationDataAfterFetchingPositiveCaseDataStep, StudyFieldsAfterFetchingPositiveCaseDataStep } from "./fetch-positive-case-data-step.js";
 
@@ -15,6 +15,7 @@ interface ValidateFieldSetFromAirtableStepInput {
   allStudies: StudyFieldsAfterFetchingPositiveCaseDataStep[];
   vaccinationData: StructuredVaccinationDataAfterFetchingPositiveCaseDataStep;
   positiveCaseData: StructuredPositiveCaseDataAfterFetchingPositiveCaseDataStep;
+  mongoClient: MongoClient;
 }
 
 interface ValidateFieldSetFromAirtableStepOutput {
@@ -22,6 +23,7 @@ interface ValidateFieldSetFromAirtableStepOutput {
   allStudies: StudyFieldsAfterValidatingFieldSetFromAirtableStep[];
   vaccinationData: StructuredVaccinationDataAfterValidatingFieldSetFromAirtableStep;
   positiveCaseData: StructuredPositiveCaseDataAfterValidatingFieldSetFromAirtableStep;
+  mongoClient: MongoClient;
 }
 
 export const validateFieldSetFromAirtableStep = (
@@ -133,6 +135,7 @@ export const validateFieldSetFromAirtableStep = (
     allEstimates,
     allStudies,
     vaccinationData: input.vaccinationData,
-    positiveCaseData: input.positiveCaseData
+    positiveCaseData: input.positiveCaseData,
+    mongoClient: input.mongoClient
   };
 };

--- a/src/lib/geocoding-api/geocoding-api-client-types.ts
+++ b/src/lib/geocoding-api/geocoding-api-client-types.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from "mongodb";
 import { TwoLetterIsoCountryCode } from "./country-codes.js";
 
 export interface MakeGeocodingApiRequestAndSaveRequestInput {
@@ -7,6 +8,7 @@ export interface MakeGeocodingApiRequestAndSaveRequestInput {
   geocodingApiRequestReportFileName: string;
   shouldSaveInGeocodingApiRequestReport: true;
   geocodingApiRequestParamOverride?: GeocodingApiRequestParameters;
+  mongoClient: MongoClient;
 }
 
 export interface MakeGeocodingApiRequestWithoutSavingRequestInput {
@@ -15,6 +17,7 @@ export interface MakeGeocodingApiRequestWithoutSavingRequestInput {
   country: string;
   shouldSaveInGeocodingApiRequestReport: false;
   geocodingApiRequestParamOverride?: GeocodingApiRequestParameters;
+  mongoClient: MongoClient;
 }
 
 export type MakeGeocodingApiRequestInput = MakeGeocodingApiRequestAndSaveRequestInput | MakeGeocodingApiRequestWithoutSavingRequestInput;

--- a/src/lib/geocoding-api/geocoding-api-client.ts
+++ b/src/lib/geocoding-api/geocoding-api-client.ts
@@ -87,6 +87,7 @@ export const makeGeocodingApiRequest = async (
     state,
     country,
     geocodingApiRequestParamOverride,
+    mongoClient
   } = input;
 
   const geocodingApiRequestParams =
@@ -103,8 +104,9 @@ export const makeGeocodingApiRequest = async (
     return "FAILED_RESPONSE";
   }
 
-  const cachedQueryValue = lookupInGeocodingApiResponseCache({
+  const cachedQueryValue = await lookupInGeocodingApiResponseCache({
     geocodingApiRequestParams,
+    mongoClient
   });
 
   if (!!cachedQueryValue && isGeocodingApiFailureResponse(cachedQueryValue)) {
@@ -134,6 +136,7 @@ export const makeGeocodingApiRequest = async (
   saveInGeocodingApiResponseCache({
     key: { geocodingApiRequestParams },
     cacheValue: parsedApiResponse,
+    mongoClient
   });
 
   if(shouldSaveInGeocodingApiRequestReport(input)) {
@@ -143,7 +146,8 @@ export const makeGeocodingApiRequest = async (
       country: country,
       geocodingApiRequestUrl: queryUrl,
       geocodingApiResponse: parsedApiResponse,
-      geocodingApiRequestReportFileName: input.geocodingApiRequestReportFileName
+      geocodingApiRequestReportFileName: input.geocodingApiRequestReportFileName,
+      mongoClient
     })
   }
 

--- a/src/lib/geocoding-api/geocoding-api-request-report-generator-types.ts
+++ b/src/lib/geocoding-api/geocoding-api-request-report-generator-types.ts
@@ -1,3 +1,4 @@
+import { MongoClient } from 'mongodb';
 import { GeocodingApiRequestUrl, GeocodingApiResponse } from "./geocoding-api-client-types.js";
 
 export enum GeocodingApiRequestLogLevel {
@@ -38,6 +39,7 @@ export interface GenerateLineForCityStateBoundingBoxConsistencyCheckInput {
   state: string | undefined;
   country: string;
   geocodingApiResponse: GeocodingApiResponse;
+  mongoClient: MongoClient;
 }
 
 export interface GenerateLineForInvalidCityButValidStateCheckInput {
@@ -45,6 +47,7 @@ export interface GenerateLineForInvalidCityButValidStateCheckInput {
   state: string | undefined;
   country: string;
   geocodingApiResponse: GeocodingApiResponse;
+  mongoClient: MongoClient;
 }
 
 export interface GenerateLineForInvalidCityButValidDistrictCheckInput {
@@ -52,6 +55,7 @@ export interface GenerateLineForInvalidCityButValidDistrictCheckInput {
   state: string | undefined;
   country: string;
   geocodingApiResponse: GeocodingApiResponse;
+  mongoClient: MongoClient;
 }
 
 export interface RecordGeocodingApiRequestInGeocodingReportInput {
@@ -61,4 +65,5 @@ export interface RecordGeocodingApiRequestInGeocodingReportInput {
   geocodingApiRequestUrl: GeocodingApiRequestUrl;
   geocodingApiResponse: GeocodingApiResponse;
   geocodingApiRequestReportFileName: string;
+  mongoClient: MongoClient;
 }

--- a/src/lib/geocoding-api/geocoding-api-response-cache-types.ts
+++ b/src/lib/geocoding-api/geocoding-api-response-cache-types.ts
@@ -1,28 +1,20 @@
-import { TwoLetterIsoCountryCode } from "./country-codes.js";
-import { GeocoderDataType, GeocodingApiFailureResponse, GeocodingApiRequestParameters, GeocodingApiSuccessResponse } from "./geocoding-api-client-types.js";
+import { MongoClient } from 'mongodb';
+import { GeocodingApiFailureResponse, GeocodingApiRequestParameters, GeocodingApiResponse, GeocodingApiSuccessResponse } from "./geocoding-api-client-types.js";
 
 export interface LookupInGeocodingApiResponseCacheInput {
   geocodingApiRequestParams: GeocodingApiRequestParameters;
+  mongoClient: MongoClient;
 }
 
 export interface SaveInGeocodingApiResponseCacheInput {
   key: {
     geocodingApiRequestParams: GeocodingApiRequestParameters
   };
-  cacheValue: GeocodingApiResponseCacheValue;
+  cacheValue: GeocodingApiResponse;
+  mongoClient: MongoClient;
 }
-
-export interface GeocodingApiResponseCacheKeyInput {
-  geocodingApiRequestParams: GeocodingApiRequestParameters;
-}
-
-export type GeocodingApiResponseCacheKey = `mapboxSearchText:${string},countryCode:${TwoLetterIsoCountryCode},geocoderDataType:${GeocoderDataType}`;
 
 export type GeocodingApiResponseCacheValue =
   | GeocodingApiSuccessResponse
   | GeocodingApiFailureResponse
   | undefined;
-export type GeocodingApiResponseCache = Record<
-  string,
-  GeocodingApiResponseCacheValue
->;

--- a/src/lib/geocoding-api/geocoding-functions-types.ts
+++ b/src/lib/geocoding-api/geocoding-functions-types.ts
@@ -1,17 +1,22 @@
-interface GetCityLatLngInput {
+import { MongoClient } from "mongodb";
+
+export interface GetCityLatLngInput {
   city: string | undefined;
   state: string | undefined;
   country: string;
   geocodingApiRequestReportFileName: string;
+  mongoClient: MongoClient;
 }
 
-interface GetStateLatLngInput {
+export interface GetStateLatLngInput {
   state: string | undefined;
   country: string;
   geocodingApiRequestReportFileName: string;
+  mongoClient: MongoClient;
 }
 
-interface GetCountryLatLngInput {
+export interface GetCountryLatLngInput {
   country: string;
   geocodingApiRequestReportFileName: string;
+  mongoClient: MongoClient;
 }

--- a/src/lib/geocoding-api/geocoding-functions.ts
+++ b/src/lib/geocoding-api/geocoding-functions.ts
@@ -3,17 +3,19 @@ import {
   Point,
   isGeocodingApiFailureResponse,
 } from "./geocoding-api-client-types.js";
+import { GetCityLatLngInput, GetCountryLatLngInput, GetStateLatLngInput } from "./geocoding-functions-types.js";
 
 export const getCityLatLng = async (
   input: GetCityLatLngInput
 ): Promise<Point | undefined> => {
-  const { city, state, country, geocodingApiRequestReportFileName } = input;
+  const { city, state, country, geocodingApiRequestReportFileName, mongoClient } = input;
 
   if (!city) {
     return getStateLatLng({
       state,
       country,
       geocodingApiRequestReportFileName,
+      mongoClient
     });
   }
 
@@ -23,6 +25,7 @@ export const getCityLatLng = async (
     country,
     geocodingApiRequestReportFileName,
     shouldSaveInGeocodingApiRequestReport: true,
+    mongoClient
   });
 
   if (isGeocodingApiFailureResponse(geocodingApiResponse)) {
@@ -30,6 +33,7 @@ export const getCityLatLng = async (
       state,
       country,
       geocodingApiRequestReportFileName,
+      mongoClient
     });
   }
 
@@ -39,10 +43,10 @@ export const getCityLatLng = async (
 const getStateLatLng = async (
   input: GetStateLatLngInput
 ): Promise<Point | undefined> => {
-  const { state, country, geocodingApiRequestReportFileName } = input;
+  const { state, country, geocodingApiRequestReportFileName, mongoClient } = input;
 
   if (!state) {
-    return getCountryLatLng({ country, geocodingApiRequestReportFileName });
+    return getCountryLatLng({ country, geocodingApiRequestReportFileName, mongoClient });
   }
 
   const geocodingApiResponse = await makeGeocodingApiRequest({
@@ -51,10 +55,11 @@ const getStateLatLng = async (
     country,
     geocodingApiRequestReportFileName,
     shouldSaveInGeocodingApiRequestReport: true,
+    mongoClient
   });
 
   if (isGeocodingApiFailureResponse(geocodingApiResponse)) {
-    return getCountryLatLng({ country, geocodingApiRequestReportFileName });
+    return getCountryLatLng({ country, geocodingApiRequestReportFileName, mongoClient });
   }
 
   return geocodingApiResponse.centerCoordinates;
@@ -63,7 +68,7 @@ const getStateLatLng = async (
 const getCountryLatLng = async (
   input: GetCountryLatLngInput
 ): Promise<Point | undefined> => {
-  const { country, geocodingApiRequestReportFileName } = input;
+  const { country, geocodingApiRequestReportFileName, mongoClient } = input;
 
   const geocodingApiResponse = await makeGeocodingApiRequest({
     city: undefined,
@@ -71,6 +76,7 @@ const getCountryLatLng = async (
     country,
     geocodingApiRequestReportFileName,
     shouldSaveInGeocodingApiRequestReport: true,
+    mongoClient
   });
 
   if (isGeocodingApiFailureResponse(geocodingApiResponse)) {

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -99,3 +99,40 @@ export interface SarsCov2EstimateDocument {
   createdAt: Date;
   updatedAt: Date;
 }
+
+export enum CachedMapboxApiResponseStatus {
+  SUCCESSFUL_RESPONSE = "SUCCESSFUL_RESPONSE",
+  FAILED_RESPONSE = "FAILED_RESPONSE",
+}
+
+interface CachedMapboxApiResponseDocumentBase {
+  _id: ObjectId;
+  mapboxSearchText: string;
+  countryCode: string;
+  geocoderDataType: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface CachedMapboxApiSuccessResponseDocument extends CachedMapboxApiResponseDocumentBase {
+  status: CachedMapboxApiResponseStatus.SUCCESSFUL_RESPONSE,
+  centerCoordinates: {
+    longitude: number;
+    latitude: number;
+  };
+  boundingBox: {
+    longitudeMinimum: number;
+    latitudeMinimum: number;
+    longitudeMaximum: number;
+    latitudeMaximum: number;
+  } | undefined;
+  text: string | undefined;
+  matchingText: string | undefined;
+  regionName: string | undefined;
+}
+
+interface CachedMapboxApiFailureResponseDocument extends CachedMapboxApiResponseDocumentBase {
+  status: CachedMapboxApiResponseStatus.FAILED_RESPONSE,
+}
+
+export type CachedMapboxApiResponseDocument = CachedMapboxApiSuccessResponseDocument | CachedMapboxApiFailureResponseDocument;


### PR DESCRIPTION
Resolves #207.

Makes the Mapbox Geocoding API cache more efficient by saving the responses to Mongo for next time instead of just in memory.