### PR TITLE
Added publication date to the SarsCov2 API

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -1551,6 +1551,18 @@
             "deprecationReason": null
           },
           {
+            "name": "publicationDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "riskOfBias",
             "description": null,
             "args": [],

--- a/src/api/graphql-types/__generated__/graphql-types.ts
+++ b/src/api/graphql-types/__generated__/graphql-types.ts
@@ -150,6 +150,7 @@ export type SarsCov2Estimate = {
   latitude: Scalars['Float']['output'];
   longitude: Scalars['Float']['output'];
   populationGroup?: Maybe<Scalars['String']['output']>;
+  publicationDate?: Maybe<Scalars['String']['output']>;
   riskOfBias?: Maybe<Scalars['String']['output']>;
   samplingEndDate?: Maybe<Scalars['String']['output']>;
   samplingMidDate?: Maybe<Scalars['String']['output']>;
@@ -440,6 +441,7 @@ export type SarsCov2EstimateResolvers<ContextType = any, ParentType extends Reso
   latitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   longitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   populationGroup?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  publicationDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   riskOfBias?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   samplingEndDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   samplingMidDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/src/api/sars-cov-2-resolvers.ts
+++ b/src/api/sars-cov-2-resolvers.ts
@@ -35,6 +35,7 @@ const transformSarsCov2EstimateDocumentForApi = (document: SarsCov2EstimateDocum
     samplingEndDate: document.samplingEndDate?.toISOString(),
     samplingStartDate: document.samplingStartDate?.toISOString(),
     samplingMidDate: document.samplingMidDate?.toISOString(),
+    publicationDate: document.publicationDate?.toISOString(),
     countryPeopleVaccinatedPerHundred: document.countryPeopleVaccinatedPerHundred,
     countryPeopleFullyVaccinatedPerHundred: document.countryPeopleFullyVaccinatedPerHundred,
     countryPositiveCasesPerMillionPeople: document.countryPositiveCasesPerMillionPeople,

--- a/src/api/sars-cov-2-typedefs.ts
+++ b/src/api/sars-cov-2-typedefs.ts
@@ -26,6 +26,7 @@ export const sarsCov2Typedefs = `
     samplingStartDate: String
     samplingEndDate: String
     samplingMidDate: String
+    publicationDate: String
     countryPeopleVaccinatedPerHundred: Float
     countryPeopleFullyVaccinatedPerHundred: Float
     countryPositiveCasesPerMillionPeople: Float

--- a/src/etl/sars-cov-2/steps/clean-field-names-and-remove-unused-fields-step.ts
+++ b/src/etl/sars-cov-2/steps/clean-field-names-and-remove-unused-fields-step.ts
@@ -23,6 +23,7 @@ export interface EstimateFieldsAfterCleaningFieldNamesStep {
   scope: string | undefined;
   samplingEndDate: string | undefined;
   samplingStartDate: string | undefined;
+  publicationDate: string | undefined;
   studyId: string | undefined;
 }
 export interface StudyFieldsAfterCleaningFieldNamesStep {
@@ -178,6 +179,7 @@ export const cleanFieldNamesAndRemoveUnusedFieldsStep = (
       scope: estimate["Grade of Estimate Scope"] ?? undefined,
       samplingEndDate: estimate["Sampling End Date"] ?? undefined,
       samplingStartDate: estimate["Sampling End Date"] ?? undefined,
+      publicationDate: estimate["Publication Date (ISO)"] ?? undefined,
       studyId: cleanArrayFieldToSingleValue({
         key: "Rapid Review: Study",
         object: estimate,

--- a/src/etl/sars-cov-2/steps/clean-field-names-and-remove-unused-fields-step.ts
+++ b/src/etl/sars-cov-2/steps/clean-field-names-and-remove-unused-fields-step.ts
@@ -179,7 +179,7 @@ export const cleanFieldNamesAndRemoveUnusedFieldsStep = (
       scope: estimate["Grade of Estimate Scope"] ?? undefined,
       samplingEndDate: estimate["Sampling End Date"] ?? undefined,
       samplingStartDate: estimate["Sampling End Date"] ?? undefined,
-      publicationDate: estimate["Publication Date (ISO)"] ?? undefined,
+      publicationDate: !isAirtableError(estimate["Publication Date (ISO)"]) && !!estimate["Publication Date (ISO)"] ? estimate["Publication Date (ISO)"] : undefined,
       studyId: cleanArrayFieldToSingleValue({
         key: "Rapid Review: Study",
         object: estimate,

--- a/src/etl/sars-cov-2/steps/parse-dates-step.ts
+++ b/src/etl/sars-cov-2/steps/parse-dates-step.ts
@@ -2,10 +2,16 @@ import { MongoClient } from "mongodb";
 import { parse } from "date-fns";
 import { EstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep, StructuredPositiveCaseDataAfterTransformingNotReportedValuesToUndefinedStep, StructuredVaccinationDataAfterTransformingNotReportedValuesToUndefinedStep, StudyFieldsAfterTransformingNotReportedValuesToUndefinedStep } from "./transform-not-reported-values-to-undefined-step.js";
 
-export type EstimateFieldsAfterParsingDatesStep = Omit<EstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep, 'samplingEndDate' | 'samplingStartDate'> & {
+export type EstimateFieldsAfterParsingDatesStep = Omit<
+  EstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep,
+  'samplingEndDate' |
+  'publicationDate' |
+  'samplingStartDate'
+> & {
   samplingStartDate: Date | undefined;
   samplingEndDate: Date | undefined;
   samplingMidDate: Date | undefined;
+  publicationDate: Date | undefined;
 };
 export type StudyFieldsAfterParsingDatesStep = StudyFieldsAfterTransformingNotReportedValuesToUndefinedStep;
 export type StructuredVaccinationDataAfterParsingDatesStep = StructuredVaccinationDataAfterTransformingNotReportedValuesToUndefinedStep;
@@ -36,13 +42,15 @@ export const parseDatesStep = (input: ParseDatesStepInput): ParseDatesStepOutput
     allEstimates: input.allEstimates.map((estimate) => {
       const samplingStartDate = estimate.samplingStartDate ? parse(estimate.samplingStartDate, "yyyy-MM-dd", new Date()) : undefined;
       const samplingEndDate = estimate.samplingStartDate ? parse(estimate.samplingStartDate, "yyyy-MM-dd", new Date()) : undefined;
+      const publicationDate = estimate.publicationDate ? parse(estimate.publicationDate, "yyyy-MM-dd", new Date()) : undefined;
       const samplingMidDate = samplingEndDate && samplingStartDate ? new Date((samplingStartDate.getTime() + samplingEndDate.getTime()) / 2) : undefined;
 
       return {
         ...estimate,
         samplingStartDate,
         samplingEndDate,
-        samplingMidDate, 
+        samplingMidDate,
+        publicationDate
       };
     }),
     allStudies: input.allStudies,

--- a/src/etl/sars-cov-2/steps/transform-into-format-for-database-step.ts
+++ b/src/etl/sars-cov-2/steps/transform-into-format-for-database-step.ts
@@ -68,6 +68,7 @@ export const transformIntoFormatForDatabaseStep = (
       samplingStartDate: estimate.samplingStartDate,
       samplingEndDate: estimate.samplingEndDate,
       samplingMidDate: estimate.samplingMidDate,
+      publicationDate: estimate.publicationDate,
       countryPeopleVaccinatedPerHundred: estimate.countryPeopleVaccinatedPerHundred,
       countryPeopleFullyVaccinatedPerHundred: estimate.countryPeopleFullyVaccinatedPerHundred,
       countryPositiveCasesPerMillionPeople: estimate.countryPositiveCasesPerMillionPeople,

--- a/src/etl/sars-cov-2/steps/validate-field-set-from-airtable-step.ts
+++ b/src/etl/sars-cov-2/steps/validate-field-set-from-airtable-step.ts
@@ -80,9 +80,10 @@ export const validateFieldSetFromAirtableStep = (
     "Sampling End Date": z
       .optional(z.string().nullable())
       .transform((field) => field ?? null),
-    "Publication Date (ISO)": z
-      .optional(z.string().nullable())
-      .transform((field) => field ?? null),
+    "Publication Date (ISO)": z.union([
+      z.optional(z.string().nullable()).transform((field) => field ?? null),
+      z.object({ error: z.string() }),
+    ]),
     "Sampling Start Date": z
       .optional(z.string().nullable())
       .transform((field) => field ?? null),

--- a/src/etl/sars-cov-2/steps/validate-field-set-from-airtable-step.ts
+++ b/src/etl/sars-cov-2/steps/validate-field-set-from-airtable-step.ts
@@ -80,6 +80,9 @@ export const validateFieldSetFromAirtableStep = (
     "Sampling End Date": z
       .optional(z.string().nullable())
       .transform((field) => field ?? null),
+    "Publication Date (ISO)": z
+      .optional(z.string().nullable())
+      .transform((field) => field ?? null),
     "Sampling Start Date": z
       .optional(z.string().nullable())
       .transform((field) => field ?? null),

--- a/src/etl/sars-cov-2/types.ts
+++ b/src/etl/sars-cov-2/types.ts
@@ -31,6 +31,7 @@ export interface AirtableSarsCov2EstimateFields {
   "Grade of Estimate Scope": string | null;
   "Sampling End Date": string | null;
   "Sampling Start Date": string | null;
+  "Publication Date (ISO)": string | null;
   "Rapid Review: Study": Array<string | null | AirtableError>;
 }
 

--- a/src/etl/sars-cov-2/types.ts
+++ b/src/etl/sars-cov-2/types.ts
@@ -31,7 +31,7 @@ export interface AirtableSarsCov2EstimateFields {
   "Grade of Estimate Scope": string | null;
   "Sampling End Date": string | null;
   "Sampling Start Date": string | null;
-  "Publication Date (ISO)": string | null;
+  "Publication Date (ISO)": string | null | AirtableError;
   "Rapid Review: Study": Array<string | null | AirtableError>;
 }
 

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -93,6 +93,7 @@ export interface SarsCov2EstimateDocument {
   samplingEndDate: Date | undefined;
   samplingStartDate: Date | undefined;
   samplingMidDate: Date | undefined;
+  publicationDate: Date | undefined;
   countryPeopleVaccinatedPerHundred: number | undefined;
   countryPeopleFullyVaccinatedPerHundred: number | undefined;
   countryPositiveCasesPerMillionPeople: number | undefined;


### PR DESCRIPTION
Part of resolving https://github.com/serotracker/dashboard/issues/221 which needs the publication date in order to generate it's graph.