### PR TITLE
Added the `estimateName` and `url` fields to the SarsCov2 API

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -1439,6 +1439,18 @@
             "deprecationReason": null
           },
           {
+            "name": "estimateName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "gbdSubRegion",
             "description": null,
             "args": [],
@@ -1741,6 +1753,18 @@
             "type": {
               "kind": "ENUM",
               "name": "UNRegion",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,

--- a/src/api/graphql-types/__generated__/graphql-types.ts
+++ b/src/api/graphql-types/__generated__/graphql-types.ts
@@ -143,6 +143,7 @@ export type SarsCov2Estimate = {
   countryPeopleVaccinatedPerHundred?: Maybe<Scalars['Float']['output']>;
   countryPositiveCasesPerMillionPeople?: Maybe<Scalars['Float']['output']>;
   denominatorValue?: Maybe<Scalars['Int']['output']>;
+  estimateName?: Maybe<Scalars['String']['output']>;
   gbdSubRegion?: Maybe<GbdSubRegion>;
   gbdSuperRegion?: Maybe<GbdSuperRegion>;
   id: Scalars['String']['output'];
@@ -165,6 +166,7 @@ export type SarsCov2Estimate = {
   studyName: Scalars['String']['output'];
   testType: Array<Scalars['String']['output']>;
   unRegion?: Maybe<UnRegion>;
+  url?: Maybe<Scalars['String']['output']>;
   whoRegion?: Maybe<WhoRegion>;
 };
 
@@ -437,6 +439,7 @@ export type SarsCov2EstimateResolvers<ContextType = any, ParentType extends Reso
   countryPeopleVaccinatedPerHundred?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   countryPositiveCasesPerMillionPeople?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   denominatorValue?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  estimateName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   gbdSubRegion?: Resolver<Maybe<ResolversTypes['GBDSubRegion']>, ParentType, ContextType>;
   gbdSuperRegion?: Resolver<Maybe<ResolversTypes['GBDSuperRegion']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -459,6 +462,7 @@ export type SarsCov2EstimateResolvers<ContextType = any, ParentType extends Reso
   studyName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   testType?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   unRegion?: Resolver<Maybe<ResolversTypes['UNRegion']>, ParentType, ContextType>;
+  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   whoRegion?: Resolver<Maybe<ResolversTypes['WHORegion']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/src/api/sars-cov-2-resolvers.ts
+++ b/src/api/sars-cov-2-resolvers.ts
@@ -46,6 +46,8 @@ const transformSarsCov2EstimateDocumentForApi = (document: SarsCov2EstimateDocum
     isWHOUnityAligned: document.isWHOUnityAligned,
     testType: document.testType,
     denominatorValue: document.denominatorValue,
+    estimateName: document.estimateName,
+    url: document.url,
     numeratorValue: document.numeratorValue,
     seroprevalence: document.seroprevalence
   }

--- a/src/api/sars-cov-2-typedefs.ts
+++ b/src/api/sars-cov-2-typedefs.ts
@@ -30,6 +30,8 @@ export const sarsCov2Typedefs = `
     denominatorValue: Int
     numeratorValue: Int
     seroprevalence: Float
+    estimateName: String
+    url: String
     countryPeopleVaccinatedPerHundred: Float
     countryPeopleFullyVaccinatedPerHundred: Float
     countryPositiveCasesPerMillionPeople: Float

--- a/src/etl/sars-cov-2/index.ts
+++ b/src/etl/sars-cov-2/index.ts
@@ -50,10 +50,6 @@ const runEtlMain = async () => {
         estimateSheet.map((record) => ({ ...record.fields, id: record.id }))
       );
     
-  console.log(allEstimatesUnformatted[0]);
-  
-  process.exit(0);
-
   const allStudiesUnformatted: (FieldSet & { id: string })[] =
     await studySheet
       .select()

--- a/src/etl/sars-cov-2/index.ts
+++ b/src/etl/sars-cov-2/index.ts
@@ -49,6 +49,10 @@ const runEtlMain = async () => {
       .then((estimateSheet) =>
         estimateSheet.map((record) => ({ ...record.fields, id: record.id }))
       );
+    
+  console.log(allEstimatesUnformatted[0]);
+  
+  process.exit(0);
 
   const allStudiesUnformatted: (FieldSet & { id: string })[] =
     await studySheet

--- a/src/etl/sars-cov-2/steps/clean-field-names-and-remove-unused-fields-step.ts
+++ b/src/etl/sars-cov-2/steps/clean-field-names-and-remove-unused-fields-step.ts
@@ -27,6 +27,8 @@ export interface EstimateFieldsAfterCleaningFieldNamesStep {
   studyId: string | undefined;
   denominatorValue: number | undefined;
   numeratorValue: number | undefined;
+  estimateName: string | undefined;
+  url: string | undefined;
 }
 export interface StudyFieldsAfterCleaningFieldNamesStep {
   id: string;
@@ -188,6 +190,11 @@ export const cleanFieldNamesAndRemoveUnusedFieldsStep = (
       }).value,
       denominatorValue: estimate['Denominator Value'] ? Math.floor(estimate['Denominator Value']) : undefined,
       numeratorValue: estimate['Numerator Value'] ? Math.floor(estimate['Numerator Value']) : undefined,
+      estimateName: estimate["Prevalence Estimate Name"] ?? undefined,
+      url: cleanArrayFieldToSingleValue({
+        key: "URL",
+        object: estimate,
+      }).value,
     })),
     allStudies: input.allStudies.map((study) => ({
       id: study.id,

--- a/src/etl/sars-cov-2/steps/transform-into-format-for-database-step.ts
+++ b/src/etl/sars-cov-2/steps/transform-into-format-for-database-step.ts
@@ -75,6 +75,8 @@ export const transformIntoFormatForDatabaseStep = (
       denominatorValue: estimate.denominatorValue,
       numeratorValue: estimate.numeratorValue,
       seroprevalence: estimate.seroprevalence,
+      estimateName: estimate.estimateName,
+      url: estimate.url,
       createdAt: createdAtForAllRecords,
       updatedAt: updatedAtForAllRecords,
     })),

--- a/src/etl/sars-cov-2/steps/validate-field-set-from-airtable-step.ts
+++ b/src/etl/sars-cov-2/steps/validate-field-set-from-airtable-step.ts
@@ -120,6 +120,15 @@ export const validateFieldSetFromAirtableStep = (
       .transform((field) => field ?? []),
     "Denominator Value": z.optional(z.number()).transform((field) => field ?? null),
     "Numerator Value": z.optional(z.number()).transform((field) => field ?? null),
+    "Prevalence Estimate Name": z.optional(z.string()).transform((field) => field ?? null),
+    "URL": z
+      .optional(
+        z.union([
+          z.string().nullable(),
+          z.object({ error: z.string() }),
+        ]).array()
+      )
+      .transform((field) => field ?? []),
   });
 
   const zodSarsCov2StudyFieldsObject = z.object({

--- a/src/etl/sars-cov-2/types.ts
+++ b/src/etl/sars-cov-2/types.ts
@@ -35,6 +35,8 @@ export interface AirtableSarsCov2EstimateFields {
   "Rapid Review: Study": Array<string | null | AirtableError>;
   "Denominator Value": number | null;
   "Numerator Value": number | null;
+  "Prevalence Estimate Name": string | null;
+  "URL": Array<string | null | AirtableError>;
 }
 
 export interface AirtableSarsCov2StudyFields {

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -100,6 +100,8 @@ export interface SarsCov2EstimateDocument {
   denominatorValue: number | undefined;
   numeratorValue: number | undefined;
   seroprevalence: number | undefined;
+  estimateName: string | undefined;
+  url: string | undefined;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
Added the `estimateName` and `url` fields to the SarsCov2 API. I need both of these fields for the improvements I want to make to the table (https://github.com/serotracker/dashboard/issues/313)