### PR TITLE
Use the new Country entity in Airtable for the Arbo ETL (some country names were mispelled in the archived column, causing failures)

### DIFF
--- a/src/etl/arbo/steps/add-country-and-region-information-step.ts
+++ b/src/etl/arbo/steps/add-country-and-region-information-step.ts
@@ -1,30 +1,37 @@
 import { MongoClient } from "mongodb";
 import {
+  AirtableCountryFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep,
   AirtableEstimateFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep,
   AirtableSourceFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep,
 } from "./remove-records-that-are-flagged-to-not-save-step.js";
-import { countryNameToThreeLetterIsoCountryCode, countryNameToTwoLetterIsoCountryCode } from "../../../lib/geocoding-api/country-codes.js";
+import { ThreeLetterIsoCountryCode, TwoLetterIsoCountryCode, countryNameToThreeLetterIsoCountryCode, countryNameToTwoLetterIsoCountryCode } from "../../../lib/geocoding-api/country-codes.js";
 import { getUNRegionFromAlphaTwoCode } from "../../../lib/un-regions.js";
 
 export type AirtableEstimateFieldsAfterAddingCountryAndRegionInformationStep =
   AirtableEstimateFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep & {
-    countryAlphaTwoCode: string;
-    countryAlphaThreeCode: string;
+    country: string;
+    countryAlphaTwoCode: TwoLetterIsoCountryCode;
+    countryAlphaThreeCode: ThreeLetterIsoCountryCode;
     unRegion: string | undefined;
   };
 
 export type AirtableSourceFieldsAfterAddingCountryAndRegionInformationStep =
   AirtableSourceFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep;
 
+export type AirtableCountryFieldsAfterAddingCountryAndRegionInformationStep =
+  AirtableCountryFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep;
+
 interface AddCountryAndRegionInformationStepInput {
   allEstimates: AirtableEstimateFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep[];
   allSources: AirtableSourceFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep[];
+  allCountries: AirtableCountryFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep[];
   mongoClient: MongoClient;
 }
 
 interface AddCountryAndRegionInformationStepOutput {
   allEstimates: AirtableEstimateFieldsAfterAddingCountryAndRegionInformationStep[];
   allSources: AirtableSourceFieldsAfterAddingCountryAndRegionInformationStep[];
+  allCountries: AirtableCountryFieldsAfterAddingCountryAndRegionInformationStep[];
   mongoClient: MongoClient;
 }
 
@@ -35,29 +42,31 @@ export const addCountryAndRegionInformationStep = (
     `Running step: addCountryAndRegionInformationStep. Remaining estimates: ${input.allEstimates.length}`
   );
 
-  const { allEstimates, allSources } = input;
+  const { allEstimates, allSources, allCountries } = input;
 
   return {
     allEstimates: allEstimates
       .map((estimate) => {
-        const countryAlphaTwoCode = countryNameToTwoLetterIsoCountryCode(
-          estimate.country
-        );
-        if (!countryAlphaTwoCode) {
+        const { countryId } = estimate;
+
+        if(!countryId) {
           return undefined;
         }
 
-        const countryAlphaThreeCode = countryNameToThreeLetterIsoCountryCode(
-          estimate.country
-        );
-        if (!countryAlphaThreeCode) {
+        const country = allCountries.find(({id}) => id === countryId);
+
+        if(!country) {
           return undefined;
         }
+
+        const countryAlphaThreeCode = country.alphaThreeCode;
+        const countryAlphaTwoCode = country.alphaTwoCode;
 
         const unRegion = getUNRegionFromAlphaTwoCode(countryAlphaTwoCode)
 
         return {
           ...estimate,
+          country: country.name,
           countryAlphaTwoCode,
           countryAlphaThreeCode,
           unRegion,
@@ -65,6 +74,7 @@ export const addCountryAndRegionInformationStep = (
       })
       .filter(<T>(estimate: T | undefined): estimate is T => !!estimate),
     allSources: allSources,
+    allCountries: allCountries,
     mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/assert-mandatory-fields-are-present-step.ts
+++ b/src/etl/arbo/steps/assert-mandatory-fields-are-present-step.ts
@@ -1,27 +1,35 @@
 import { MongoClient } from "mongodb";
-import { AirtableEstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep, AirtableSourceFieldsAfterTransformingNotReportedValuesToUndefinedStep } from "./transform-not-reported-values-to-undefined-step.js";
+import {
+  AirtableCountryFieldsAfterTransformingNotReportedValuesToUndefinedStep,
+  AirtableEstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep,
+  AirtableSourceFieldsAfterTransformingNotReportedValuesToUndefinedStep
+} from "./transform-not-reported-values-to-undefined-step.js";
 
 export type AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep =
   Omit<
     AirtableEstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep,
-    "country" | "pathogen"
+    "pathogen"
   > & {
-    country: string;
     pathogen: string;
   };
 
 export type AirtableSourceFieldsAfterAssertingMandatoryFieldsArePresentStep =
   AirtableSourceFieldsAfterTransformingNotReportedValuesToUndefinedStep;
 
+export type AirtableCountryFieldsAfterAssertingMandatoryFieldsArePresentStep =
+  AirtableCountryFieldsAfterTransformingNotReportedValuesToUndefinedStep;
+
 interface AssertMandatoryFieldsArePresentStepInput {
   allEstimates: AirtableEstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
   allSources: AirtableSourceFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
+  allCountries: AirtableCountryFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
   mongoClient: MongoClient;
 }
 
 interface AssertMandatoryFieldsAreStepOutput {
   allEstimates: AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep[];
   allSources: AirtableSourceFieldsAfterAssertingMandatoryFieldsArePresentStep[];
+  allCountries: AirtableCountryFieldsAfterAssertingMandatoryFieldsArePresentStep[];
   mongoClient: MongoClient;
 }
 
@@ -30,13 +38,14 @@ export const assertMandatoryFieldsArePresentStep = (
 ): AssertMandatoryFieldsAreStepOutput => {
   console.log(`Running step: assertMandatoryFieldsArePresentStep. Remaining estimates: ${input.allEstimates.length}`);
 
-  const { allEstimates, allSources } = input;
+  const { allEstimates, allSources, allCountries } = input;
 
   return {
     allEstimates: allEstimates.filter((estimate): estimate is AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep => {
-      return !!estimate.country && !!estimate.pathogen;
+      return !!estimate.pathogen;
     }),
     allSources: allSources,
+    allCountries: allCountries,
     mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/clean-single-element-array-fields-step.ts
+++ b/src/etl/arbo/steps/clean-single-element-array-fields-step.ts
@@ -1,30 +1,37 @@
 import { MongoClient } from "mongodb";
 import {
   AirtableEstimateFieldsAfterCleaningFieldNamesAndRemoveUnusedFieldsStep,
-  AirtableSourceFieldsCleaningFieldNamesAndRemoveUnusedFieldsStep,
+  AirtableSourceFieldsAfterCleaningFieldNamesAndRemoveUnusedFieldsStep,
+  AirtableCountryFieldsAfterCleaningFieldNamesAndRemoveUnusedFieldsStep,
 } from "./clean-field-names-and-remove-unused-fields-step.js";
 
 export type AirtableEstimateFieldsAfterCleaningSingleElementArrayFieldsStep = Omit<
   AirtableEstimateFieldsAfterCleaningFieldNamesAndRemoveUnusedFieldsStep,
-  "url" | "sourceSheetId" | "whoRegion"
+  "url" | "sourceSheetId" | "whoRegion" | "countryId"
 > & {
   url: string | undefined;
   sourceSheetId: string | undefined;
   whoRegion: string | undefined;
+  countryId: string | undefined;
 };
 
 export type AirtableSourceFieldsAfterCleaningSingleElementArrayFieldsStep =
-  AirtableSourceFieldsCleaningFieldNamesAndRemoveUnusedFieldsStep;
+  AirtableSourceFieldsAfterCleaningFieldNamesAndRemoveUnusedFieldsStep;
+
+export type AirtableCountryFieldsAfterCleaningSingleElementArrayFieldsStep =
+  AirtableCountryFieldsAfterCleaningFieldNamesAndRemoveUnusedFieldsStep;
 
 interface CleanSingleElementArrayFieldsStepInput {
   allEstimates: AirtableEstimateFieldsAfterCleaningFieldNamesAndRemoveUnusedFieldsStep[];
-  allSources: AirtableSourceFieldsCleaningFieldNamesAndRemoveUnusedFieldsStep[];
+  allSources: AirtableSourceFieldsAfterCleaningFieldNamesAndRemoveUnusedFieldsStep[];
+  allCountries: AirtableCountryFieldsAfterCleaningFieldNamesAndRemoveUnusedFieldsStep[];
   mongoClient: MongoClient;
 }
 
 interface CleanSingleElementArrayFieldsStepOutput {
   allEstimates: AirtableEstimateFieldsAfterCleaningSingleElementArrayFieldsStep[];
   allSources: AirtableSourceFieldsAfterCleaningSingleElementArrayFieldsStep[];
+  allCountries: AirtableCountryFieldsAfterCleaningSingleElementArrayFieldsStep[];
   mongoClient: MongoClient;
 }
 
@@ -33,7 +40,7 @@ export const cleanSingleElementArrayFieldsStep = (
 ): CleanSingleElementArrayFieldsStepOutput => {
   console.log(`Running step: cleanSingleElementArrayFieldsStep. Remaining estimates: ${input.allEstimates.length}`);
 
-  const { allEstimates, allSources } = input;
+  const { allEstimates, allSources, allCountries } = input;
 
   return {
     allEstimates: allEstimates.map((estimate) => {
@@ -42,9 +49,11 @@ export const cleanSingleElementArrayFieldsStep = (
         url: estimate.url?.[0],
         sourceSheetId: estimate.sourceSheetId?.[0],
         whoRegion: estimate.whoRegion?.[0],
+        countryId: estimate.countryId?.[0],
       };
     }),
     allSources: allSources,
+    allCountries: allCountries,
     mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/jitter-pin-lat-lng-step.ts
+++ b/src/etl/arbo/steps/jitter-pin-lat-lng-step.ts
@@ -1,9 +1,13 @@
 import { MongoClient } from "mongodb";
-import { AirtableEstimateFieldsAfterLatLngGenerationStep, AirtableSourceFieldsAfterLatLngGenerationStep } from "./lat-lng-generation-step.js";
+import {
+  AirtableCountryFieldsAfterLatLngGenerationStep,
+  AirtableEstimateFieldsAfterLatLngGenerationStep,
+  AirtableSourceFieldsAfterLatLngGenerationStep
+} from "./lat-lng-generation-step.js";
 
 export type AirtableEstimateFieldsAfterJitteringPinLatLngStep = AirtableEstimateFieldsAfterLatLngGenerationStep;
-
 export type AirtableSourceFieldsAfterJitteringPinLatLngStep = AirtableSourceFieldsAfterLatLngGenerationStep
+export type AirtableCountryFieldsAfterJitteringPinLatLngStep = AirtableCountryFieldsAfterLatLngGenerationStep
 
 interface JitterNumberValueByAmountInput {
   value: number;
@@ -22,22 +26,24 @@ const jitterNumberValueByAmount = (input: JitterNumberValueByAmountInput): numbe
 interface JitterPinLatLngStepInput {
   allEstimates: AirtableEstimateFieldsAfterLatLngGenerationStep[];
   allSources: AirtableSourceFieldsAfterLatLngGenerationStep[];
+  allCountries: AirtableCountryFieldsAfterLatLngGenerationStep[];
   mongoClient: MongoClient;
 }
 
 interface JitterPinLatLngStepOutput {
   allEstimates: AirtableEstimateFieldsAfterJitteringPinLatLngStep[];
   allSources: AirtableSourceFieldsAfterJitteringPinLatLngStep[];
+  allCountries: AirtableCountryFieldsAfterJitteringPinLatLngStep[];
   mongoClient: MongoClient;
 }
 
 export const jitterPinLatLngStep = (
   input: JitterPinLatLngStepInput
 ): JitterPinLatLngStepOutput => {
-  const { allEstimates, allSources } = input;
   const maximumPinJitterMagnitude = 0.1;
-
   console.log(`Running step: jitterPinLatLngStep. Remaining estimates: ${input.allEstimates.length}. Maximum pin jitter mangnitude: ${maximumPinJitterMagnitude}`);
+
+  const { allEstimates, allSources, allCountries } = input;
 
   return {
     allEstimates: allEstimates.map((estimate) => ({
@@ -46,6 +52,7 @@ export const jitterPinLatLngStep = (
       longitude: jitterNumberValueByAmount({value: estimate.longitude, jitterAmount: maximumPinJitterMagnitude}),
     })),
     allSources: allSources,
+    allCountries: allCountries,
     mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/lat-lng-generation-step.ts
+++ b/src/etl/arbo/steps/lat-lng-generation-step.ts
@@ -4,6 +4,7 @@ import { getLatitude, getLongitude } from "../../../lib/geocoding-api/coordinate
 import { Point } from "../../../lib/geocoding-api/geocoding-api-client-types.js";
 import { getCityLatLng } from "../../../lib/geocoding-api/geocoding-functions.js";
 import {
+  AirtableCountryFieldsAfterMergingEstimatesAndSourcesStep,
   AirtableEstimateFieldsAfterMergingEstimatesAndSourcesStep,
   AirtableSourceFieldsAfterMergingEstimatesAndSourcesStep,
 } from "./merge-estimates-and-sources-step.js";
@@ -17,15 +18,20 @@ export type AirtableEstimateFieldsAfterLatLngGenerationStep =
 export type AirtableSourceFieldsAfterLatLngGenerationStep =
   AirtableSourceFieldsAfterMergingEstimatesAndSourcesStep;
 
+export type AirtableCountryFieldsAfterLatLngGenerationStep =
+  AirtableCountryFieldsAfterMergingEstimatesAndSourcesStep;
+
 interface LatLngGenerationStepInput {
   allEstimates: AirtableEstimateFieldsAfterMergingEstimatesAndSourcesStep[];
   allSources: AirtableSourceFieldsAfterMergingEstimatesAndSourcesStep[];
+  allCountries: AirtableCountryFieldsAfterMergingEstimatesAndSourcesStep[];
   mongoClient: MongoClient;
 }
 
 interface LatLngGenerationStepOutput {
   allEstimates: AirtableEstimateFieldsAfterLatLngGenerationStep[];
   allSources: AirtableSourceFieldsAfterLatLngGenerationStep[];
+  allCountries: AirtableCountryFieldsAfterLatLngGenerationStep[];
   mongoClient: MongoClient;
 }
 
@@ -39,7 +45,7 @@ export const latLngGenerationStep = async(
 
   console.log(`Running step: latLngGenerationStep. Remaining estimates: ${input.allEstimates.length}. GEOCODING_API_ENABLED=${geocodingApiEnabled}`);
 
-  const { allEstimates, allSources } = input;
+  const { allEstimates, allSources, allCountries } = input;
 
   const intervalsToPrintProgressMessages = Array.from({length: 20}, (_, index) => Math.floor((allEstimates.length * (index + 1)) / 20));
 
@@ -55,7 +61,8 @@ export const latLngGenerationStep = async(
       cityLatLng = await getCityLatLng({
         city: estimate.city,
         state: estimate.state,
-        country: estimate.country,
+        countryName: estimate.country,
+        countryAlphaTwoCode: estimate.countryAlphaTwoCode,
         geocodingApiRequestReportFileName,
         mongoClient: input.mongoClient
       })
@@ -73,6 +80,7 @@ export const latLngGenerationStep = async(
   return {
     allEstimates: estimatesWithLatitudesAndLongitudes,
     allSources: allSources,
+    allCountries: allCountries,
     mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/merge-estimates-and-sources-step.ts
+++ b/src/etl/arbo/steps/merge-estimates-and-sources-step.ts
@@ -1,5 +1,6 @@
 import { MongoClient } from "mongodb";
 import {
+  AirtableCountryFieldsAfterAddingCountryAndRegionInformationStep,
   AirtableEstimateFieldsAfterAddingCountryAndRegionInformationStep,
   AirtableSourceFieldsAfterAddingCountryAndRegionInformationStep
 } from "./add-country-and-region-information-step.js";
@@ -12,15 +13,20 @@ export type AirtableEstimateFieldsAfterMergingEstimatesAndSourcesStep =
 export type AirtableSourceFieldsAfterMergingEstimatesAndSourcesStep =
   AirtableSourceFieldsAfterAddingCountryAndRegionInformationStep;
 
+export type AirtableCountryFieldsAfterMergingEstimatesAndSourcesStep =
+  AirtableCountryFieldsAfterAddingCountryAndRegionInformationStep;
+
 interface MergeEstimatesAndSourcesStepInput {
   allEstimates: AirtableEstimateFieldsAfterAddingCountryAndRegionInformationStep[];
   allSources: AirtableSourceFieldsAfterAddingCountryAndRegionInformationStep[];
+  allCountries: AirtableCountryFieldsAfterAddingCountryAndRegionInformationStep[];
   mongoClient: MongoClient;
 }
 
 interface MergeEstimatesAndSourcesStepOutput {
   allEstimates: AirtableEstimateFieldsAfterMergingEstimatesAndSourcesStep[];
   allSources: AirtableSourceFieldsAfterMergingEstimatesAndSourcesStep[];
+  allCountries: AirtableCountryFieldsAfterMergingEstimatesAndSourcesStep[];
   mongoClient: MongoClient;
 }
 
@@ -29,7 +35,7 @@ export const mergeEstimatesAndSourcesStep = (
 ): MergeEstimatesAndSourcesStepOutput => {
   console.log(`Running step: mergeEstimatesAndSourcesStep. Remaining estimates: ${input.allEstimates.length}`);
 
-  const { allEstimates, allSources } = input;
+  const { allEstimates, allSources, allCountries } = input;
 
   return {
     allEstimates: allEstimates.map((estimate) => {
@@ -43,6 +49,7 @@ export const mergeEstimatesAndSourcesStep = (
       };
     }),
     allSources: allSources,
+    allCountries: allCountries,
     mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/parse-dates-step.ts
+++ b/src/etl/arbo/steps/parse-dates-step.ts
@@ -1,6 +1,10 @@
 import { MongoClient } from "mongodb";
 import { parse } from "date-fns";
-import { AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep, AirtableSourceFieldsAfterAssertingMandatoryFieldsArePresentStep } from "./assert-mandatory-fields-are-present-step.js";
+import {
+  AirtableCountryFieldsAfterAssertingMandatoryFieldsArePresentStep,
+  AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep,
+  AirtableSourceFieldsAfterAssertingMandatoryFieldsArePresentStep
+} from "./assert-mandatory-fields-are-present-step.js";
 
 export type AirtableEstimateFieldsAfterParsingDatesStep = Omit<
   AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep,
@@ -13,15 +17,20 @@ export type AirtableEstimateFieldsAfterParsingDatesStep = Omit<
 export type AirtableSourceFieldsAfterParsingDatesStep =
   AirtableSourceFieldsAfterAssertingMandatoryFieldsArePresentStep;
 
+export type AirtableCountryFieldsAfterParsingDatesStep =
+  AirtableCountryFieldsAfterAssertingMandatoryFieldsArePresentStep;
+
 interface ParseDatesStepInput {
   allEstimates: AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep[];
-  allSources: AirtableSourceFieldsAfterParsingDatesStep[];
+  allSources: AirtableSourceFieldsAfterAssertingMandatoryFieldsArePresentStep[];
+  allCountries: AirtableCountryFieldsAfterAssertingMandatoryFieldsArePresentStep[];
   mongoClient: MongoClient;
 }
 
 interface ParseDatesStepOutput {
   allEstimates: AirtableEstimateFieldsAfterParsingDatesStep[];
   allSources: AirtableSourceFieldsAfterParsingDatesStep[];
+  allCountries: AirtableCountryFieldsAfterParsingDatesStep[];
   mongoClient: MongoClient;
 }
 
@@ -30,7 +39,7 @@ export const parseDatesStep = (
 ): ParseDatesStepOutput => {
   console.log(`Running step: parseDatesStep. Remaining estimates: ${input.allEstimates.length}`);
 
-  const { allEstimates, allSources } = input;
+  const { allEstimates, allSources, allCountries } = input;
 
   return {
     allEstimates: allEstimates.map((estimate) => {
@@ -41,6 +50,7 @@ export const parseDatesStep = (
       };
     }),
     allSources: allSources,
+    allCountries: allCountries,
     mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/remove-estimates-with-low-sample-size-step.ts
+++ b/src/etl/arbo/steps/remove-estimates-with-low-sample-size-step.ts
@@ -1,5 +1,6 @@
 import { MongoClient } from "mongodb";
 import {
+  AirtableCountryFieldsAfterParsingDatesStep,
   AirtableEstimateFieldsAfterParsingDatesStep,
   AirtableSourceFieldsAfterParsingDatesStep,
 } from "./parse-dates-step.js";
@@ -10,15 +11,20 @@ export type AirtableEstimateFieldsAfterRemovingEstimatesWithLowSampleSizeStep =
 export type AirtableSourceFieldsAfterRemovingEstimatesWithLowSampleSizeStep =
   AirtableSourceFieldsAfterParsingDatesStep;
 
+export type AirtableCountryFieldsAfterRemovingEstimatesWithLowSampleSizeStep =
+  AirtableCountryFieldsAfterParsingDatesStep;
+
 interface RemoveEstimatesWithLowSampleSizeStepInput {
   allEstimates: AirtableEstimateFieldsAfterParsingDatesStep[];
   allSources: AirtableSourceFieldsAfterParsingDatesStep[];
+  allCountries: AirtableCountryFieldsAfterParsingDatesStep[];
   mongoClient: MongoClient;
 }
 
 interface RemoveEstimatesWithLowSampleSizeStepOutput {
   allEstimates: AirtableEstimateFieldsAfterRemovingEstimatesWithLowSampleSizeStep[];
   allSources: AirtableSourceFieldsAfterRemovingEstimatesWithLowSampleSizeStep[];
+  allCountries: AirtableCountryFieldsAfterRemovingEstimatesWithLowSampleSizeStep[];
   mongoClient: MongoClient;
 }
 
@@ -29,7 +35,7 @@ export const removeEstimatesWithLowSampleSizeStep = (
 
   console.log(`Running step: removeEstimatesWithLowSampleSizeStep. minimumSampleSize=${minimumSampleSize}. Remaining estimates: ${input.allEstimates.length}`);
 
-  const { allEstimates, allSources } = input;
+  const { allEstimates, allSources, allCountries } = input;
 
   return {
     allEstimates: allEstimates.filter((estimate): estimate is AirtableEstimateFieldsAfterRemovingEstimatesWithLowSampleSizeStep => {
@@ -44,6 +50,7 @@ export const removeEstimatesWithLowSampleSizeStep = (
       return true;
     }),
     allSources: allSources,
+    allCountries: allCountries,
     mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/remove-records-that-are-flagged-to-not-save-step.ts
+++ b/src/etl/arbo/steps/remove-records-that-are-flagged-to-not-save-step.ts
@@ -1,5 +1,6 @@
 import { MongoClient } from "mongodb";
 import {
+  AirtableCountryFieldsAfterRemovingEstimatesWithLowSampleSizeStep,
   AirtableEstimateFieldsAfterRemovingEstimatesWithLowSampleSizeStep,
   AirtableSourceFieldsAfterRemovingEstimatesWithLowSampleSizeStep,
 } from "./remove-estimates-with-low-sample-size-step.js";
@@ -12,30 +13,36 @@ export type AirtableEstimateFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveSte
 export type AirtableSourceFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep =
   AirtableSourceFieldsAfterRemovingEstimatesWithLowSampleSizeStep;
 
+export type AirtableCountryFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep =
+  AirtableCountryFieldsAfterRemovingEstimatesWithLowSampleSizeStep;
+
 interface RemoveRecordsThatAreFlaggedToNotSaveStepInput {
   allEstimates: AirtableEstimateFieldsAfterRemovingEstimatesWithLowSampleSizeStep[];
   allSources: AirtableSourceFieldsAfterRemovingEstimatesWithLowSampleSizeStep[];
+  allCountries: AirtableCountryFieldsAfterRemovingEstimatesWithLowSampleSizeStep[];
   mongoClient: MongoClient;
 }
 
 interface RemoveRecordsThatAreFlaggedToNotSaveStepOutput {
   allEstimates: AirtableEstimateFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep[];
   allSources: AirtableSourceFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep[];
+  allCountries: AirtableCountryFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep[];
   mongoClient: MongoClient;
 }
 
 export const removeRecordsThatAreFlaggedToNotSaveStep = (
   input: RemoveRecordsThatAreFlaggedToNotSaveStepInput
 ): RemoveRecordsThatAreFlaggedToNotSaveStepOutput => {
-  const { allEstimates, allSources } = input;
-
   console.log(`Running step: removeRecordsThatAreFlaggedToNotSaveStep. Remaining estimates: ${input.allEstimates.length}`);
+
+  const { allEstimates, allSources, allCountries } = input;
 
   return {
     allEstimates: allEstimates.filter((estimate): estimate is AirtableEstimateFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep =>
       estimate.includeInEtl === 1
     ),
     allSources: allSources,
+    allCountries: allCountries,
     mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/transform-into-format-for-database-step.ts
+++ b/src/etl/arbo/steps/transform-into-format-for-database-step.ts
@@ -1,32 +1,35 @@
 import { ObjectId, MongoClient } from "mongodb";
 import { ArbovirusEstimateDocument } from "../../../storage/types.js";
 import {
+  AirtableCountryFieldsAfterJitteringPinLatLngStep,
   AirtableEstimateFieldsAfterJitteringPinLatLngStep,
   AirtableSourceFieldsAfterJitteringPinLatLngStep,
 } from "./jitter-pin-lat-lng-step.js";
 
-export type AirtableEstimateFieldsAfterTransformingIntoFormatForDatabaseStep = AirtableEstimateFieldsAfterJitteringPinLatLngStep;
-
+export type AirtableEstimateFieldsAfterTransformingIntoFormatForDatabaseStep = ArbovirusEstimateDocument;
 export type AirtableSourceFieldsAfterTransformingIntoFormatForDatabaseStep = AirtableSourceFieldsAfterJitteringPinLatLngStep;
+export type AirtableCountryFieldsAfterTransformingIntoFormatForDatabaseStep = AirtableCountryFieldsAfterJitteringPinLatLngStep;
 
 interface TransformIntoFormatForDatabaseStepInput {
   allEstimates: AirtableEstimateFieldsAfterJitteringPinLatLngStep[];
   allSources: AirtableSourceFieldsAfterJitteringPinLatLngStep[];
+  allCountries: AirtableCountryFieldsAfterJitteringPinLatLngStep[];
   mongoClient: MongoClient;
 }
 
 interface TransformIntoFormatForDatabaseStepOutput {
-  allEstimates: ArbovirusEstimateDocument[];
+  allEstimates: AirtableEstimateFieldsAfterTransformingIntoFormatForDatabaseStep[];
   allSources: AirtableSourceFieldsAfterTransformingIntoFormatForDatabaseStep[];
+  allCountries: AirtableCountryFieldsAfterTransformingIntoFormatForDatabaseStep[];
   mongoClient: MongoClient;
 }
 
 export const transformIntoFormatForDatabaseStep = (
   input: TransformIntoFormatForDatabaseStepInput
 ): TransformIntoFormatForDatabaseStepOutput => {
-  const { allEstimates, allSources } = input;
-
   console.log(`Running step: transformIntoFormatForDatabaseStep. Remaining estimates: ${input.allEstimates.length}`);
+
+  const { allEstimates, allSources, allCountries } = input;
 
   const createdAtForAllRecords = new Date();
   const updatedAtForAllRecords = createdAtForAllRecords;
@@ -76,6 +79,7 @@ export const transformIntoFormatForDatabaseStep = (
       updatedAt: updatedAtForAllRecords
     })),
     allSources: allSources,
+    allCountries: allCountries,
     mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/transform-not-reported-values-to-undefined-step.ts
+++ b/src/etl/arbo/steps/transform-not-reported-values-to-undefined-step.ts
@@ -1,6 +1,7 @@
 import { MongoClient } from "mongodb";
 import { isArrayOfUnknownType } from "../../../lib/lib.js";
 import {
+  AirtableCountryFieldsAfterCleaningSingleElementArrayFieldsStep,
   AirtableEstimateFieldsAfterCleaningSingleElementArrayFieldsStep,
   AirtableSourceFieldsAfterCleaningSingleElementArrayFieldsStep,
 } from "./clean-single-element-array-fields-step.js";
@@ -11,15 +12,20 @@ export type AirtableEstimateFieldsAfterTransformingNotReportedValuesToUndefinedS
 export type AirtableSourceFieldsAfterTransformingNotReportedValuesToUndefinedStep =
   AirtableSourceFieldsAfterCleaningSingleElementArrayFieldsStep;
 
+export type AirtableCountryFieldsAfterTransformingNotReportedValuesToUndefinedStep =
+  AirtableCountryFieldsAfterCleaningSingleElementArrayFieldsStep;
+
 interface TransformNotReportedValuesToUndefinedStepInput {
   allEstimates: AirtableEstimateFieldsAfterCleaningSingleElementArrayFieldsStep[];
   allSources: AirtableSourceFieldsAfterCleaningSingleElementArrayFieldsStep[];
+  allCountries: AirtableCountryFieldsAfterCleaningSingleElementArrayFieldsStep[];
   mongoClient: MongoClient;
 }
 
 interface TransformNotReportedValuesToUndefinedStepOutput {
   allEstimates: AirtableEstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
   allSources: AirtableSourceFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
+  allCountries: AirtableCountryFieldsAfterTransformingNotReportedValuesToUndefinedStep[];
   mongoClient: MongoClient;
 }
 
@@ -43,7 +49,7 @@ export const transformNotReportedValuesToUndefinedStep = (
 ): TransformNotReportedValuesToUndefinedStepOutput => {
   console.log(`Running step: transformNotReportedValuesToUndefinedStep. Remaining estimates: ${input.allEstimates.length}`);
 
-  const { allEstimates, allSources } = input;
+  const { allEstimates, allSources, allCountries } = input;
 
   return {
     allEstimates: allEstimates.map(
@@ -63,6 +69,7 @@ export const transformNotReportedValuesToUndefinedStep = (
         ) as AirtableEstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep
     ),
     allSources: allSources,
+    allCountries: allCountries,
     mongoClient: input.mongoClient
   };
 };

--- a/src/etl/arbo/steps/validate-field-set-from-airtable-step.ts
+++ b/src/etl/arbo/steps/validate-field-set-from-airtable-step.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { MongoClient } from "mongodb";
+import { FieldSet } from "airtable";
+import { AirtableEstimateFields, AirtableSourceFields, AirtableCountryFields } from "../types.js";
+
+export type AirtableEstimateFieldsAfterValidatingFieldSetFromAirtableStep = AirtableEstimateFields;
+export type AirtableSourceFieldsAfterValidatingFieldSetFromAirtableStep = AirtableSourceFields;
+export type AirtableCountryFieldsAfterValidatingFieldSetFromAirtableStep = AirtableCountryFields;
+
+interface ValidateFieldSetFromAirtableStepInput {
+  allEstimates: AirtableEstimateFields[];
+  allSources: AirtableSourceFields[];
+  allCountries: Array<FieldSet & {id: string}>;
+  mongoClient: MongoClient;
+}
+
+interface ValidateFieldSetFromAirtableStepOutput {
+  allEstimates: AirtableEstimateFieldsAfterValidatingFieldSetFromAirtableStep[];
+  allSources: AirtableSourceFieldsAfterValidatingFieldSetFromAirtableStep[];
+  allCountries: AirtableCountryFieldsAfterValidatingFieldSetFromAirtableStep[];
+  mongoClient: MongoClient;
+}
+
+export const validateFieldSetFromAirtableStep = (
+  input: ValidateFieldSetFromAirtableStepInput
+): ValidateFieldSetFromAirtableStepOutput => {
+  console.log(`Running step: validateFieldSetFromAirtableStep. Remaining estimates: ${input.allEstimates.length}.`);
+
+  const zodCountryFieldsObject = z.object({
+    id: z.string(),
+    Country: z.string(),
+    "Alpha3 Code": z.string(),
+    "Alpha2 Code": z.string()
+  })
+
+  const allCountries = input.allCountries.map((country) => zodCountryFieldsObject.parse(country));
+
+  return {
+    allEstimates: input.allEstimates,
+    allSources: input.allSources,
+    allCountries: allCountries,
+    mongoClient: input.mongoClient
+  };
+};

--- a/src/etl/arbo/types.ts
+++ b/src/etl/arbo/types.ts
@@ -31,10 +31,9 @@ export type AirtableEstimateFields = {
   "Seroprevalence 95% CI Upper (formula)": number | undefined;
   "Subgroups Available": string[] | undefined;
   Continent: string | undefined;
-  "Country archive": string | undefined;
+  "Country": string[] | undefined;
   "Sample Numerator": number | undefined;
   URL: string[] | undefined;
-  Country: string | undefined;
   "Age group": string | undefined;
   City: string | undefined;
   State: string | undefined;
@@ -54,3 +53,10 @@ export type AirtableSourceFields = {
   Extractor: string | undefined;
   "First Author Last Name": string | undefined;
 } & Record<string, never>;
+
+export type AirtableCountryFields = {
+  "id": string;
+  "Country": string;
+  "Alpha3 Code": string;
+  "Alpha2 Code": string;
+}

--- a/src/etl/sars-cov-2/steps/lat-lng-generation-step.ts
+++ b/src/etl/sars-cov-2/steps/lat-lng-generation-step.ts
@@ -55,7 +55,8 @@ export const latLngGenerationStep = async(
       cityLatLng = await getCityLatLng({
         city: estimate.city,
         state: estimate.state,
-        country: estimate.country,
+        countryName: estimate.country,
+        countryAlphaTwoCode: estimate.countryAlphaTwoCode,
         geocodingApiRequestReportFileName,
         mongoClient: input.mongoClient
       })

--- a/src/lib/geocoding-api/geocoding-api-client-types.ts
+++ b/src/lib/geocoding-api/geocoding-api-client-types.ts
@@ -4,7 +4,8 @@ import { TwoLetterIsoCountryCode } from "./country-codes.js";
 export interface MakeGeocodingApiRequestAndSaveRequestInput {
   city: string | undefined;
   state: string | undefined;
-  country: string;
+  countryName: string;
+  countryAlphaTwoCode: TwoLetterIsoCountryCode;
   geocodingApiRequestReportFileName: string;
   shouldSaveInGeocodingApiRequestReport: true;
   geocodingApiRequestParamOverride?: GeocodingApiRequestParameters;
@@ -14,7 +15,8 @@ export interface MakeGeocodingApiRequestAndSaveRequestInput {
 export interface MakeGeocodingApiRequestWithoutSavingRequestInput {
   city: string | undefined;
   state: string | undefined;
-  country: string;
+  countryName: string;
+  countryAlphaTwoCode: TwoLetterIsoCountryCode;
   shouldSaveInGeocodingApiRequestReport: false;
   geocodingApiRequestParamOverride?: GeocodingApiRequestParameters;
   mongoClient: MongoClient;
@@ -39,12 +41,13 @@ export enum GeocoderDataType {
 export interface GenerateGeocodingApiRequestParametersInput {
   city: string | undefined;
   state: string | undefined;
-  country: string;
+  countryName: string;
+  countryAlphaTwoCode: TwoLetterIsoCountryCode;
 }
 
 export interface GeocodingApiRequestParameters {
   mapboxSearchText: string;
-  countryCode: TwoLetterIsoCountryCode;
+  countryAlphaTwoCode: TwoLetterIsoCountryCode;
   geocoderDataType: GeocoderDataType;
 }
 

--- a/src/lib/geocoding-api/geocoding-api-request-report-generator-types.ts
+++ b/src/lib/geocoding-api/geocoding-api-request-report-generator-types.ts
@@ -1,5 +1,6 @@
 import { MongoClient } from 'mongodb';
 import { GeocodingApiRequestUrl, GeocodingApiResponse } from "./geocoding-api-client-types.js";
+import { TwoLetterIsoCountryCode } from './country-codes.js';
 
 export enum GeocodingApiRequestLogLevel {
   INFO = "INFO",
@@ -10,7 +11,8 @@ export enum GeocodingApiRequestLogLevel {
 export interface GenerateGeocodingApiRequestLogPrefixInput {
   city: string | undefined;
   state: string | undefined;
-  country: string;
+  countryName: string;
+  countryAlphaTwoCode: TwoLetterIsoCountryCode;
   logLevel: GeocodingApiRequestLogLevel;
 }
 
@@ -22,7 +24,8 @@ export interface FormatTextAndMatchingTextForDisplayInput {
 export interface GenerateLineForRequestAndResponseInput {
   city: string | undefined;
   state: string | undefined;
-  country: string;
+  countryName: string;
+  countryAlphaTwoCode: TwoLetterIsoCountryCode;
   geocodingApiRequestUrl: GeocodingApiRequestUrl;
   geocodingApiResponse: GeocodingApiResponse;
 }
@@ -30,14 +33,16 @@ export interface GenerateLineForRequestAndResponseInput {
 export interface GenerateLineForTextConsistencyCheckInput {
   city: string | undefined;
   state: string | undefined;
-  country: string;
+  countryName: string;
+  countryAlphaTwoCode: TwoLetterIsoCountryCode;
   geocodingApiResponse: GeocodingApiResponse;
 }
 
 export interface GenerateLineForCityStateBoundingBoxConsistencyCheckInput {
   city: string | undefined;
   state: string | undefined;
-  country: string;
+  countryName: string;
+  countryAlphaTwoCode: TwoLetterIsoCountryCode;
   geocodingApiResponse: GeocodingApiResponse;
   mongoClient: MongoClient;
 }
@@ -45,7 +50,8 @@ export interface GenerateLineForCityStateBoundingBoxConsistencyCheckInput {
 export interface GenerateLineForInvalidCityButValidStateCheckInput {
   city: string | undefined;
   state: string | undefined;
-  country: string;
+  countryName: string;
+  countryAlphaTwoCode: TwoLetterIsoCountryCode;
   geocodingApiResponse: GeocodingApiResponse;
   mongoClient: MongoClient;
 }
@@ -53,7 +59,8 @@ export interface GenerateLineForInvalidCityButValidStateCheckInput {
 export interface GenerateLineForInvalidCityButValidDistrictCheckInput {
   city: string | undefined;
   state: string | undefined;
-  country: string;
+  countryName: string;
+  countryAlphaTwoCode: TwoLetterIsoCountryCode;
   geocodingApiResponse: GeocodingApiResponse;
   mongoClient: MongoClient;
 }
@@ -61,7 +68,8 @@ export interface GenerateLineForInvalidCityButValidDistrictCheckInput {
 export interface RecordGeocodingApiRequestInGeocodingReportInput {
   city: string | undefined,
   state: string | undefined,
-  country: string,
+  countryName: string;
+  countryAlphaTwoCode: TwoLetterIsoCountryCode;
   geocodingApiRequestUrl: GeocodingApiRequestUrl;
   geocodingApiResponse: GeocodingApiResponse;
   geocodingApiRequestReportFileName: string;

--- a/src/lib/geocoding-api/geocoding-api-response-cache.ts
+++ b/src/lib/geocoding-api/geocoding-api-response-cache.ts
@@ -19,7 +19,7 @@ export const lookupInGeocodingApiResponseCache = async(
     .collection<CachedMapboxApiResponseDocument>('mapboxGeocodingApiCachedResponses')
     .find({
       mapboxSearchText: geocodingApiRequestParams.mapboxSearchText,
-      countryCode: geocodingApiRequestParams.countryCode,
+      countryCode: geocodingApiRequestParams.countryAlphaTwoCode,
       geocoderDataType: geocodingApiRequestParams.geocoderDataType
     })
     .sort({createdAt: -1, _id: 1})
@@ -71,7 +71,7 @@ export const saveInGeocodingApiResponseCache = async(
         _id: new ObjectId(),
         status: CachedMapboxApiResponseStatus.FAILED_RESPONSE,
         mapboxSearchText: geocodingApiRequestParams.mapboxSearchText,
-        countryCode: geocodingApiRequestParams.countryCode,
+        countryCode: geocodingApiRequestParams.countryAlphaTwoCode,
         geocoderDataType: geocodingApiRequestParams.geocoderDataType,
         createdAt: cacheEntryCreationDate,
         updatedAt: cacheEntryCreationDate,
@@ -87,7 +87,7 @@ export const saveInGeocodingApiResponseCache = async(
       _id: new ObjectId(),
       status: CachedMapboxApiResponseStatus.SUCCESSFUL_RESPONSE,
       mapboxSearchText: geocodingApiRequestParams.mapboxSearchText,
-      countryCode: geocodingApiRequestParams.countryCode,
+      countryCode: geocodingApiRequestParams.countryAlphaTwoCode,
       geocoderDataType: geocodingApiRequestParams.geocoderDataType,
       centerCoordinates: {
         longitude: cacheValue.centerCoordinates[0],

--- a/src/lib/geocoding-api/geocoding-functions-types.ts
+++ b/src/lib/geocoding-api/geocoding-functions-types.ts
@@ -1,22 +1,26 @@
 import { MongoClient } from "mongodb";
+import { TwoLetterIsoCountryCode } from "./country-codes";
 
 export interface GetCityLatLngInput {
   city: string | undefined;
   state: string | undefined;
-  country: string;
+  countryName: string;
+  countryAlphaTwoCode: TwoLetterIsoCountryCode;
   geocodingApiRequestReportFileName: string;
   mongoClient: MongoClient;
 }
 
 export interface GetStateLatLngInput {
   state: string | undefined;
-  country: string;
+  countryName: string;
+  countryAlphaTwoCode: TwoLetterIsoCountryCode;
   geocodingApiRequestReportFileName: string;
   mongoClient: MongoClient;
 }
 
 export interface GetCountryLatLngInput {
-  country: string;
+  countryName: string;
+  countryAlphaTwoCode: TwoLetterIsoCountryCode;
   geocodingApiRequestReportFileName: string;
   mongoClient: MongoClient;
 }

--- a/src/lib/geocoding-api/geocoding-functions.ts
+++ b/src/lib/geocoding-api/geocoding-functions.ts
@@ -8,12 +8,13 @@ import { GetCityLatLngInput, GetCountryLatLngInput, GetStateLatLngInput } from "
 export const getCityLatLng = async (
   input: GetCityLatLngInput
 ): Promise<Point | undefined> => {
-  const { city, state, country, geocodingApiRequestReportFileName, mongoClient } = input;
+  const { city, state, countryName, countryAlphaTwoCode, geocodingApiRequestReportFileName, mongoClient } = input;
 
   if (!city) {
     return getStateLatLng({
       state,
-      country,
+      countryName,
+      countryAlphaTwoCode,
       geocodingApiRequestReportFileName,
       mongoClient
     });
@@ -22,7 +23,8 @@ export const getCityLatLng = async (
   const geocodingApiResponse = await makeGeocodingApiRequest({
     city,
     state,
-    country,
+    countryName,
+    countryAlphaTwoCode,
     geocodingApiRequestReportFileName,
     shouldSaveInGeocodingApiRequestReport: true,
     mongoClient
@@ -31,7 +33,8 @@ export const getCityLatLng = async (
   if (isGeocodingApiFailureResponse(geocodingApiResponse)) {
     return getStateLatLng({
       state,
-      country,
+      countryName,
+      countryAlphaTwoCode,
       geocodingApiRequestReportFileName,
       mongoClient
     });
@@ -43,23 +46,24 @@ export const getCityLatLng = async (
 const getStateLatLng = async (
   input: GetStateLatLngInput
 ): Promise<Point | undefined> => {
-  const { state, country, geocodingApiRequestReportFileName, mongoClient } = input;
+  const { state, countryName, countryAlphaTwoCode, geocodingApiRequestReportFileName, mongoClient } = input;
 
   if (!state) {
-    return getCountryLatLng({ country, geocodingApiRequestReportFileName, mongoClient });
+    return getCountryLatLng({ countryName, countryAlphaTwoCode, geocodingApiRequestReportFileName, mongoClient });
   }
 
   const geocodingApiResponse = await makeGeocodingApiRequest({
     city: undefined,
     state,
-    country,
+    countryName,
+    countryAlphaTwoCode,
     geocodingApiRequestReportFileName,
     shouldSaveInGeocodingApiRequestReport: true,
     mongoClient
   });
 
   if (isGeocodingApiFailureResponse(geocodingApiResponse)) {
-    return getCountryLatLng({ country, geocodingApiRequestReportFileName, mongoClient });
+    return getCountryLatLng({ countryName, countryAlphaTwoCode, geocodingApiRequestReportFileName, mongoClient });
   }
 
   return geocodingApiResponse.centerCoordinates;
@@ -68,12 +72,13 @@ const getStateLatLng = async (
 const getCountryLatLng = async (
   input: GetCountryLatLngInput
 ): Promise<Point | undefined> => {
-  const { country, geocodingApiRequestReportFileName, mongoClient } = input;
+  const { countryName, countryAlphaTwoCode, geocodingApiRequestReportFileName, mongoClient } = input;
 
   const geocodingApiResponse = await makeGeocodingApiRequest({
     city: undefined,
     state: undefined,
-    country,
+    countryName,
+    countryAlphaTwoCode,
     geocodingApiRequestReportFileName,
     shouldSaveInGeocodingApiRequestReport: true,
     mongoClient


### PR DESCRIPTION
Some of the estimates in the table had misspelled country names which was causing errors because it would be unable to find an alpha2/3 code for them. I'll do the SC2 ETL at some point in the future, just doing the Arbo one first.

![image](https://github.com/serotracker/iit-backend-v2/assets/86806388/e51a56c5-c3bd-4c8b-bd0c-17da353fbe62)
