### PR TITLE
Improved our method of connecting vaccination data to estimates

### DIFF
--- a/src/etl/sars-cov-2/steps/add-positive-case-data-to-estimate-step.ts
+++ b/src/etl/sars-cov-2/steps/add-positive-case-data-to-estimate-step.ts
@@ -8,109 +8,6 @@ import {
 } from "./add-vaccination-data-to-estimate-step";
 import { StructuredPositiveCaseData } from "../types";
 
-interface GetAssociatedPositiveCaseDataForEstimateInput {
-  estimate: {
-    twoLetterCountryCode: string;
-    samplingMidDate: Date | undefined;
-  };
-  positiveCaseData: StructuredPositiveCaseData;
-  acceptableDayDifferenceRange: number;
-}
-
-interface GetAssociatedPositiveCaseDataForEstimateOutput {
-  countryPositiveCasesPerMillionPeople: number | undefined;
-}
-
-const getAssociatedPositiveCaseDataForEstimate = (input: GetAssociatedPositiveCaseDataForEstimateInput): GetAssociatedPositiveCaseDataForEstimateOutput => {
-  const { samplingMidDate } = input.estimate;
-
-  if(!samplingMidDate) {
-    return { countryPositiveCasesPerMillionPeople: undefined };
-  }
-
-  const acceptableDayDifferences = [...Array(input.acceptableDayDifferenceRange).keys()];
-
-  const dayDifferencesWithData = acceptableDayDifferences.flatMap((dayDifference) => {
-    const pastDateToEvaluate = sub(samplingMidDate, {days: dayDifference});
-    const futureDateToEvaluate = add(samplingMidDate, {days: dayDifference});
-
-    const dataForPastDateToEvaluate = input.positiveCaseData
-      .find((element) => element.twoLetterCountryCode === input.estimate.twoLetterCountryCode)?.data
-      .find((element) => element.year === pastDateToEvaluate.getUTCFullYear().toString())?.data
-      .find((element) => element.month === (pastDateToEvaluate.getUTCMonth() + 1).toString())?.data
-      .find((element) => element.day === (pastDateToEvaluate.getUTCDate()).toString());
-
-    const dataForFutureDateToEvaluate = input.positiveCaseData
-      .find((element) => element.twoLetterCountryCode === input.estimate.twoLetterCountryCode)?.data
-      .find((element) => element.year === futureDateToEvaluate.getUTCFullYear().toString())?.data
-      .find((element) => element.month === (futureDateToEvaluate.getUTCMonth() + 1).toString())?.data
-      .find((element) => element.day === (futureDateToEvaluate.getUTCDate()).toString());
-
-    return [(
-      (
-        dataForPastDateToEvaluate !== undefined &&
-        dataForPastDateToEvaluate.countryPositiveCasesPerMillionPeople !== undefined
-      ) ? {
-        dayDifference: -dayDifference,
-        data: {
-          countryPositiveCasesPerMillionPeople: dataForPastDateToEvaluate.countryPositiveCasesPerMillionPeople
-        }
-      } : undefined
-    ), (
-      (
-        dataForFutureDateToEvaluate !== undefined &&
-        dataForFutureDateToEvaluate.countryPositiveCasesPerMillionPeople !== undefined
-      ) ? {
-        dayDifference: dayDifference,
-        data: {
-          countryPositiveCasesPerMillionPeople: dataForFutureDateToEvaluate.countryPositiveCasesPerMillionPeople
-        }
-      } : undefined
-    )];
-  }).filter(<T extends unknown>(element: T | undefined): element is T => element !== undefined)
-
-  const dataForDay = dayDifferencesWithData.find((element) => element.dayDifference === 0)
-
-  if(!!dataForDay) {
-    return {
-      countryPositiveCasesPerMillionPeople: dataForDay.data.countryPositiveCasesPerMillionPeople
-    }
-  }
-
-  const dayInThePastWithTheLeastDifference = dayDifferencesWithData
-    .filter((element) => element.dayDifference < 0)
-    .sort((a, b) => Math.abs(a.dayDifference) - Math.abs(b.dayDifference))
-    .at(0);
-
-  const dayInTheFutureWithTheLeastDifference = dayDifferencesWithData
-    .filter((element) => element.dayDifference > 0)
-    .sort((a, b) => Math.abs(a.dayDifference) - Math.abs(b.dayDifference))
-    .at(0);
-  
-  if(dayInThePastWithTheLeastDifference && dayInTheFutureWithTheLeastDifference) {
-    // Turn this into a line with a slope of y=mx+b where x is the date.
-    // We approximate the line to be linear on such a small time scale (~14 days).
-
-    // m = dy/dx
-    const m = (dayInTheFutureWithTheLeastDifference.data.countryPositiveCasesPerMillionPeople - dayInThePastWithTheLeastDifference.data.countryPositiveCasesPerMillionPeople) / (dayInTheFutureWithTheLeastDifference.dayDifference - dayInThePastWithTheLeastDifference.dayDifference);
-
-    // b = y-mx
-    const b = (dayInTheFutureWithTheLeastDifference.data.countryPositiveCasesPerMillionPeople) - (m * dayInTheFutureWithTheLeastDifference.dayDifference)
-
-    // y = mx+b, x=0 in this case because the day difference is zero
-    const countryPositiveCasesPerMillionPeople = (m * 0) + b;
-
-    return {
-      countryPositiveCasesPerMillionPeople
-    }
-  }
-
-  // Getting here means we simply didn't have enough data to tell how many positive cases had occurred at this time.
-  return {
-    countryPositiveCasesPerMillionPeople: undefined
-  }
-}
-
 export type EstimateFieldsAfterAddingPositiveCaseDataStep =
   EstimateFieldsAfterAddingVaccinationDataStep & { 
     countryPositiveCasesPerMillionPeople: number | undefined;
@@ -141,23 +38,18 @@ interface AddPositiveCaseDataToEstimateStepOutput {
 export const addPositiveCaseDataToEstimateStep = (
   input: AddPositiveCaseDataToEstimateStepInput
 ): AddPositiveCaseDataToEstimateStepOutput => {
-  const acceptableDayDifferenceRange = 7;
-
   console.log(
-    `Running step: addPositiveCaseDataToEstimateStep. Remaining estimates: ${input.allEstimates.length}. Acceptable day difference range: ${acceptableDayDifferenceRange}`
+    `Running step: addPositiveCaseDataToEstimateStep. Remaining estimates: ${input.allEstimates.length}`
   );
 
   return {
     allEstimates: input.allEstimates.map((estimate) => ({
       ...estimate,
-      countryPositiveCasesPerMillionPeople: getAssociatedPositiveCaseDataForEstimate({
-        estimate: {
-          twoLetterCountryCode: estimate.countryAlphaTwoCode,
-          samplingMidDate: estimate.samplingMidDate
-        },
-        positiveCaseData: input.positiveCaseData,
-        acceptableDayDifferenceRange
-      }).countryPositiveCasesPerMillionPeople
+      countryPositiveCasesPerMillionPeople: input.positiveCaseData
+        .find((element) => element.twoLetterCountryCode === estimate.countryAlphaTwoCode)?.data
+        .find((element) => estimate.samplingMidDate && element.year === estimate.samplingMidDate.getUTCFullYear().toString())?.data
+        .find((element) => estimate.samplingMidDate && element.month === (estimate.samplingMidDate.getUTCMonth() + 1).toString())?.data
+        .find((element) => estimate.samplingMidDate && element.day === (estimate.samplingMidDate.getUTCDate()).toString())?.countryPositiveCasesPerMillionPeople
     })),
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,

--- a/src/etl/sars-cov-2/steps/add-positive-case-data-to-estimate-step.ts
+++ b/src/etl/sars-cov-2/steps/add-positive-case-data-to-estimate-step.ts
@@ -1,5 +1,115 @@
 import { MongoClient } from "mongodb";
-import { EstimateFieldsAfterAddingVaccinationDataStep, StructuredPositiveCaseDataAfterAddingVaccinationDataStep, StructuredVaccinationDataAfterAddingVaccinationDataStep, StudyFieldsAfterAddingVaccinationDataStep } from "./add-vaccination-data-to-estimate-step";
+import { add, sub } from 'date-fns';
+import {
+  EstimateFieldsAfterAddingVaccinationDataStep,
+  StructuredPositiveCaseDataAfterAddingVaccinationDataStep,
+  StructuredVaccinationDataAfterAddingVaccinationDataStep,
+  StudyFieldsAfterAddingVaccinationDataStep
+} from "./add-vaccination-data-to-estimate-step";
+import { StructuredPositiveCaseData } from "../types";
+
+interface GetAssociatedPositiveCaseDataForEstimateInput {
+  estimate: {
+    twoLetterCountryCode: string;
+    samplingMidDate: Date | undefined;
+  };
+  positiveCaseData: StructuredPositiveCaseData;
+  acceptableDayDifferenceRange: number;
+}
+
+interface GetAssociatedPositiveCaseDataForEstimateOutput {
+  countryPositiveCasesPerMillionPeople: number | undefined;
+}
+
+const getAssociatedPositiveCaseDataForEstimate = (input: GetAssociatedPositiveCaseDataForEstimateInput): GetAssociatedPositiveCaseDataForEstimateOutput => {
+  const { samplingMidDate } = input.estimate;
+
+  if(!samplingMidDate) {
+    return { countryPositiveCasesPerMillionPeople: undefined };
+  }
+
+  const acceptableDayDifferences = [...Array(input.acceptableDayDifferenceRange).keys()];
+
+  const dayDifferencesWithData = acceptableDayDifferences.flatMap((dayDifference) => {
+    const pastDateToEvaluate = sub(samplingMidDate, {days: dayDifference});
+    const futureDateToEvaluate = add(samplingMidDate, {days: dayDifference});
+
+    const dataForPastDateToEvaluate = input.positiveCaseData
+      .find((element) => element.twoLetterCountryCode === input.estimate.twoLetterCountryCode)?.data
+      .find((element) => element.year === pastDateToEvaluate.getUTCFullYear().toString())?.data
+      .find((element) => element.month === (pastDateToEvaluate.getUTCMonth() + 1).toString())?.data
+      .find((element) => element.day === (pastDateToEvaluate.getUTCDate()).toString());
+
+    const dataForFutureDateToEvaluate = input.positiveCaseData
+      .find((element) => element.twoLetterCountryCode === input.estimate.twoLetterCountryCode)?.data
+      .find((element) => element.year === futureDateToEvaluate.getUTCFullYear().toString())?.data
+      .find((element) => element.month === (futureDateToEvaluate.getUTCMonth() + 1).toString())?.data
+      .find((element) => element.day === (futureDateToEvaluate.getUTCDate()).toString());
+
+    return [(
+      (
+        dataForPastDateToEvaluate !== undefined &&
+        dataForPastDateToEvaluate.countryPositiveCasesPerMillionPeople !== undefined
+      ) ? {
+        dayDifference: -dayDifference,
+        data: {
+          countryPositiveCasesPerMillionPeople: dataForPastDateToEvaluate.countryPositiveCasesPerMillionPeople
+        }
+      } : undefined
+    ), (
+      (
+        dataForFutureDateToEvaluate !== undefined &&
+        dataForFutureDateToEvaluate.countryPositiveCasesPerMillionPeople !== undefined
+      ) ? {
+        dayDifference: dayDifference,
+        data: {
+          countryPositiveCasesPerMillionPeople: dataForFutureDateToEvaluate.countryPositiveCasesPerMillionPeople
+        }
+      } : undefined
+    )];
+  }).filter(<T extends unknown>(element: T | undefined): element is T => element !== undefined)
+
+  const dataForDay = dayDifferencesWithData.find((element) => element.dayDifference === 0)
+
+  if(!!dataForDay) {
+    return {
+      countryPositiveCasesPerMillionPeople: dataForDay.data.countryPositiveCasesPerMillionPeople
+    }
+  }
+
+  const dayInThePastWithTheLeastDifference = dayDifferencesWithData
+    .filter((element) => element.dayDifference < 0)
+    .sort((a, b) => Math.abs(a.dayDifference) - Math.abs(b.dayDifference))
+    .at(0);
+
+  const dayInTheFutureWithTheLeastDifference = dayDifferencesWithData
+    .filter((element) => element.dayDifference > 0)
+    .sort((a, b) => Math.abs(a.dayDifference) - Math.abs(b.dayDifference))
+    .at(0);
+  
+  if(dayInThePastWithTheLeastDifference && dayInTheFutureWithTheLeastDifference) {
+    // Turn this into a line with a slope of y=mx+b where x is the date.
+    // We approximate the line to be linear on such a small time scale (~14 days).
+
+    // m = dy/dx
+    const m = (dayInTheFutureWithTheLeastDifference.data.countryPositiveCasesPerMillionPeople - dayInThePastWithTheLeastDifference.data.countryPositiveCasesPerMillionPeople) / (dayInTheFutureWithTheLeastDifference.dayDifference - dayInThePastWithTheLeastDifference.dayDifference);
+
+    // b = y-mx
+    const b = (dayInTheFutureWithTheLeastDifference.data.countryPositiveCasesPerMillionPeople) - (m * dayInTheFutureWithTheLeastDifference.dayDifference)
+
+    // y = mx+b, x=0 in this case because the day difference is zero
+    const countryPositiveCasesPerMillionPeople = (m * 0) + b;
+
+    return {
+      countryPositiveCasesPerMillionPeople
+    }
+  }
+
+  // Getting here means we simply didn't have enough data to tell how many positive cases had occurred at this time.
+  return {
+    countryPositiveCasesPerMillionPeople: undefined
+  }
+}
 
 export type EstimateFieldsAfterAddingPositiveCaseDataStep =
   EstimateFieldsAfterAddingVaccinationDataStep & { 
@@ -31,18 +141,23 @@ interface AddPositiveCaseDataToEstimateStepOutput {
 export const addPositiveCaseDataToEstimateStep = (
   input: AddPositiveCaseDataToEstimateStepInput
 ): AddPositiveCaseDataToEstimateStepOutput => {
+  const acceptableDayDifferenceRange = 7;
+
   console.log(
-    `Running step: addPositiveCaseDataToEstimateStep. Remaining estimates: ${input.allEstimates.length}`
+    `Running step: addPositiveCaseDataToEstimateStep. Remaining estimates: ${input.allEstimates.length}. Acceptable day difference range: ${acceptableDayDifferenceRange}`
   );
 
   return {
     allEstimates: input.allEstimates.map((estimate) => ({
       ...estimate,
-      countryPositiveCasesPerMillionPeople: input.positiveCaseData
-        .find((element) => element.twoLetterCountryCode === estimate.countryAlphaTwoCode)?.data
-        .find((element) => estimate.samplingMidDate && element.year === estimate.samplingMidDate.getUTCFullYear().toString())?.data
-        .find((element) => estimate.samplingMidDate && element.month === (estimate.samplingMidDate.getUTCMonth() + 1).toString())?.data
-        .find((element) => estimate.samplingMidDate && element.day === (estimate.samplingMidDate.getUTCDate()).toString())?.countryPositiveCasesPerMillionPeople
+      countryPositiveCasesPerMillionPeople: getAssociatedPositiveCaseDataForEstimate({
+        estimate: {
+          twoLetterCountryCode: estimate.countryAlphaTwoCode,
+          samplingMidDate: estimate.samplingMidDate
+        },
+        positiveCaseData: input.positiveCaseData,
+        acceptableDayDifferenceRange
+      }).countryPositiveCasesPerMillionPeople
     })),
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,

--- a/src/etl/sars-cov-2/steps/add-positive-case-data-to-estimate-step.ts
+++ b/src/etl/sars-cov-2/steps/add-positive-case-data-to-estimate-step.ts
@@ -1,12 +1,5 @@
 import { MongoClient } from "mongodb";
-import { add, sub } from 'date-fns';
-import {
-  EstimateFieldsAfterAddingVaccinationDataStep,
-  StructuredPositiveCaseDataAfterAddingVaccinationDataStep,
-  StructuredVaccinationDataAfterAddingVaccinationDataStep,
-  StudyFieldsAfterAddingVaccinationDataStep
-} from "./add-vaccination-data-to-estimate-step";
-import { StructuredPositiveCaseData } from "../types";
+import { EstimateFieldsAfterAddingVaccinationDataStep, StructuredPositiveCaseDataAfterAddingVaccinationDataStep, StructuredVaccinationDataAfterAddingVaccinationDataStep, StudyFieldsAfterAddingVaccinationDataStep } from "./add-vaccination-data-to-estimate-step";
 
 export type EstimateFieldsAfterAddingPositiveCaseDataStep =
   EstimateFieldsAfterAddingVaccinationDataStep & { 

--- a/src/etl/sars-cov-2/steps/add-vaccination-data-to-estimate-step.ts
+++ b/src/etl/sars-cov-2/steps/add-vaccination-data-to-estimate-step.ts
@@ -248,7 +248,7 @@ interface AddVaccinationDataToEstimateStepOutput {
 export const addVaccinationDataToEstimateStep = (
   input: AddVaccinationDataToEstimateStepInput
 ): AddVaccinationDataToEstimateStepOutput => {
-  const acceptableDayDifferenceRange = 7;
+  const acceptableDayDifferenceRange = 31;
 
   console.log(
     `Running step: addVaccinationDataToEstimateStep. Remaining estimates: ${input.allEstimates.length}. Acceptable day difference range: ${acceptableDayDifferenceRange}`

--- a/src/etl/sars-cov-2/steps/add-vaccination-data-to-estimate-step.ts
+++ b/src/etl/sars-cov-2/steps/add-vaccination-data-to-estimate-step.ts
@@ -1,10 +1,222 @@
 import { MongoClient } from "mongodb";
+import { add, sub } from 'date-fns';
 import {
   EstimateFieldsAfterJitteringPinLatLngStep,
   StructuredPositiveCaseDataAfterJitteringPinLatLngStep,
   StructuredVaccinationDataAfterJitteringPinLatLngStep,
   StudyFieldsAfterJitteringPinLatLngStep,
 } from "./jitter-pin-lat-lng-step";
+import { StructuredVaccinationData } from "../types";
+
+interface GetAssociatedVaccinationDataForEstimateInput {
+  estimate: {
+    threeLetterCountryCode: string;
+    samplingMidDate: Date | undefined;
+  };
+  vaccinationData: StructuredVaccinationData;
+  acceptableDayDifferenceRange: number;
+}
+
+interface GetAssociatedVaccinationDataForEstimateOutput {
+  countryPeopleVaccinatedPerHundred: number | undefined;
+}
+
+const getAssociatedVaccinationDataForEstimate = (input: GetAssociatedVaccinationDataForEstimateInput): GetAssociatedVaccinationDataForEstimateOutput => {
+  const { samplingMidDate } = input.estimate;
+
+  if(!samplingMidDate) {
+    return {
+      countryPeopleVaccinatedPerHundred: undefined,
+    };
+  }
+
+  const acceptableDayDifferences = [...Array(input.acceptableDayDifferenceRange).keys()];
+
+  const dayDifferencesWithData = acceptableDayDifferences.flatMap((dayDifference) => {
+    const pastDateToEvaluate = sub(samplingMidDate, {days: dayDifference});
+    const futureDateToEvaluate = add(samplingMidDate, {days: dayDifference});
+
+    const dataForPastDateToEvaluate = input.vaccinationData
+      .find((element) => element.threeLetterCountryCode === input.estimate.threeLetterCountryCode)?.data
+      .find((element) => element.year === pastDateToEvaluate.getUTCFullYear().toString())?.data
+      .find((element) => element.month === (pastDateToEvaluate.getUTCMonth() + 1).toString())?.data
+      .find((element) => element.day === (pastDateToEvaluate.getUTCDate()).toString());
+
+    const dataForFutureDateToEvaluate = input.vaccinationData
+      .find((element) => element.threeLetterCountryCode === input.estimate.threeLetterCountryCode)?.data
+      .find((element) => element.year === futureDateToEvaluate.getUTCFullYear().toString())?.data
+      .find((element) => element.month === (futureDateToEvaluate.getUTCMonth() + 1).toString())?.data
+      .find((element) => element.day === (futureDateToEvaluate.getUTCDate()).toString());
+
+    return [(
+      (
+        dataForPastDateToEvaluate !== undefined &&
+        dataForPastDateToEvaluate.countryPeopleVaccinatedPerHundred !== undefined
+      ) ? {
+        dayDifference: -dayDifference,
+        data: {
+          countryPeopleVaccinatedPerHundred: dataForPastDateToEvaluate.countryPeopleVaccinatedPerHundred,
+        }
+      } : undefined
+    ), (
+      (
+        dataForFutureDateToEvaluate !== undefined &&
+        dataForFutureDateToEvaluate.countryPeopleVaccinatedPerHundred !== undefined
+      ) ? {
+        dayDifference: dayDifference,
+        data: {
+          countryPeopleVaccinatedPerHundred: dataForFutureDateToEvaluate.countryPeopleVaccinatedPerHundred,
+        }
+      } : undefined
+    )];
+  }).filter(<T extends unknown>(element: T | undefined): element is T => element !== undefined)
+
+  const dataForDay = dayDifferencesWithData.find((element) => element.dayDifference === 0)
+
+  if(!!dataForDay) {
+    return {
+      countryPeopleVaccinatedPerHundred: dataForDay.data.countryPeopleVaccinatedPerHundred,
+    }
+  }
+
+  const dayInThePastWithTheLeastDifference = dayDifferencesWithData
+    .filter((element) => element.dayDifference < 0)
+    .sort((a, b) => Math.abs(a.dayDifference) - Math.abs(b.dayDifference))
+    .at(0);
+
+  const dayInTheFutureWithTheLeastDifference = dayDifferencesWithData
+    .filter((element) => element.dayDifference > 0)
+    .sort((a, b) => Math.abs(a.dayDifference) - Math.abs(b.dayDifference))
+    .at(0);
+  
+  if(dayInThePastWithTheLeastDifference && dayInTheFutureWithTheLeastDifference) {
+    // Turn this into a line with a slope of y=mx+b where x is the date.
+    // We approximate the line to be linear on such a small time scale (~14 days).
+
+    // m = dy/dx
+    const m = (dayInTheFutureWithTheLeastDifference.data.countryPeopleVaccinatedPerHundred - dayInThePastWithTheLeastDifference.data.countryPeopleVaccinatedPerHundred) / (dayInTheFutureWithTheLeastDifference.dayDifference - dayInThePastWithTheLeastDifference.dayDifference);
+
+    // b = y-mx
+    const b = (dayInTheFutureWithTheLeastDifference.data.countryPeopleVaccinatedPerHundred) - (m * dayInTheFutureWithTheLeastDifference.dayDifference)
+
+    // y = mx+b, x=0 in this case because the day difference is zero
+    const countryPeopleVaccinatedPerHundred = (m * 0) + b;
+
+    return {
+      countryPeopleVaccinatedPerHundred
+    }
+  }
+
+  // Getting here means we simply didn't have enough data to tell how many positive cases had occurred at this time.
+  return {
+    countryPeopleVaccinatedPerHundred: undefined
+  }
+}
+
+interface GetAssociatedFullVaccinationDataForEstimateInput {
+  estimate: {
+    threeLetterCountryCode: string;
+    samplingMidDate: Date | undefined;
+  };
+  vaccinationData: StructuredVaccinationData;
+  acceptableDayDifferenceRange: number;
+}
+
+interface GetAssociatedFullVaccinationDataForEstimateOutput {
+  countryPeopleFullyVaccinatedPerHundred: number | undefined;
+}
+
+const getAssociatedFullVaccinationDataForEstimate = (input: GetAssociatedFullVaccinationDataForEstimateInput): GetAssociatedFullVaccinationDataForEstimateOutput => {
+  const { samplingMidDate } = input.estimate;
+
+  if(!samplingMidDate) {
+    return {
+      countryPeopleFullyVaccinatedPerHundred: undefined,
+    };
+  }
+
+  const acceptableDayDifferences = [...Array(input.acceptableDayDifferenceRange).keys()];
+
+  const dayDifferencesWithData = acceptableDayDifferences.flatMap((dayDifference) => {
+    const pastDateToEvaluate = sub(samplingMidDate, {days: dayDifference});
+    const futureDateToEvaluate = add(samplingMidDate, {days: dayDifference});
+
+    const dataForPastDateToEvaluate = input.vaccinationData
+      .find((element) => element.threeLetterCountryCode === input.estimate.threeLetterCountryCode)?.data
+      .find((element) => element.year === pastDateToEvaluate.getUTCFullYear().toString())?.data
+      .find((element) => element.month === (pastDateToEvaluate.getUTCMonth() + 1).toString())?.data
+      .find((element) => element.day === (pastDateToEvaluate.getUTCDate()).toString());
+
+    const dataForFutureDateToEvaluate = input.vaccinationData
+      .find((element) => element.threeLetterCountryCode === input.estimate.threeLetterCountryCode)?.data
+      .find((element) => element.year === futureDateToEvaluate.getUTCFullYear().toString())?.data
+      .find((element) => element.month === (futureDateToEvaluate.getUTCMonth() + 1).toString())?.data
+      .find((element) => element.day === (futureDateToEvaluate.getUTCDate()).toString());
+
+    return [(
+      (
+        dataForPastDateToEvaluate !== undefined &&
+        dataForPastDateToEvaluate.countryPeopleFullyVaccinatedPerHundred !== undefined
+      ) ? {
+        dayDifference: -dayDifference,
+        data: {
+          countryPeopleFullyVaccinatedPerHundred: dataForPastDateToEvaluate.countryPeopleFullyVaccinatedPerHundred,
+        }
+      } : undefined
+    ), (
+      (
+        dataForFutureDateToEvaluate !== undefined &&
+        dataForFutureDateToEvaluate.countryPeopleFullyVaccinatedPerHundred !== undefined
+      ) ? {
+        dayDifference: dayDifference,
+        data: {
+          countryPeopleFullyVaccinatedPerHundred: dataForFutureDateToEvaluate.countryPeopleFullyVaccinatedPerHundred,
+        }
+      } : undefined
+    )];
+  }).filter(<T extends unknown>(element: T | undefined): element is T => element !== undefined)
+
+  const dataForDay = dayDifferencesWithData.find((element) => element.dayDifference === 0)
+
+  if(!!dataForDay) {
+    return {
+      countryPeopleFullyVaccinatedPerHundred: dataForDay.data.countryPeopleFullyVaccinatedPerHundred,
+    }
+  }
+
+  const dayInThePastWithTheLeastDifference = dayDifferencesWithData
+    .filter((element) => element.dayDifference < 0)
+    .sort((a, b) => Math.abs(a.dayDifference) - Math.abs(b.dayDifference))
+    .at(0);
+
+  const dayInTheFutureWithTheLeastDifference = dayDifferencesWithData
+    .filter((element) => element.dayDifference > 0)
+    .sort((a, b) => Math.abs(a.dayDifference) - Math.abs(b.dayDifference))
+    .at(0);
+  
+  if(dayInThePastWithTheLeastDifference && dayInTheFutureWithTheLeastDifference) {
+    // Turn this into a line with a slope of y=mx+b where x is the date.
+    // We approximate the line to be linear on such a small time scale (~14 days).
+
+    // m = dy/dx
+    const m = (dayInTheFutureWithTheLeastDifference.data.countryPeopleFullyVaccinatedPerHundred - dayInThePastWithTheLeastDifference.data.countryPeopleFullyVaccinatedPerHundred) / (dayInTheFutureWithTheLeastDifference.dayDifference - dayInThePastWithTheLeastDifference.dayDifference);
+
+    // b = y-mx
+    const b = (dayInTheFutureWithTheLeastDifference.data.countryPeopleFullyVaccinatedPerHundred) - (m * dayInTheFutureWithTheLeastDifference.dayDifference)
+
+    // y = mx+b, x=0 in this case because the day difference is zero
+    const countryPeopleFullyVaccinatedPerHundred = (m * 0) + b;
+
+    return {
+      countryPeopleFullyVaccinatedPerHundred
+    }
+  }
+
+  // Getting here means we simply didn't have enough data to tell how many positive cases had occurred at this time.
+  return {
+    countryPeopleFullyVaccinatedPerHundred: undefined
+  }
+}
 
 export type EstimateFieldsAfterAddingVaccinationDataStep =
   EstimateFieldsAfterJitteringPinLatLngStep & {
@@ -36,29 +248,32 @@ interface AddVaccinationDataToEstimateStepOutput {
 export const addVaccinationDataToEstimateStep = (
   input: AddVaccinationDataToEstimateStepInput
 ): AddVaccinationDataToEstimateStepOutput => {
+  const acceptableDayDifferenceRange = 7;
+
   console.log(
-    `Running step: addVaccinationDataToEstimateStep. Remaining estimates: ${input.allEstimates.length}`
+    `Running step: addVaccinationDataToEstimateStep. Remaining estimates: ${input.allEstimates.length}. Acceptable day difference range: ${acceptableDayDifferenceRange}`
   );
 
   return {
-    allEstimates: input.allEstimates.map((estimate) => {
-      const {
-        countryPeopleVaccinatedPerHundred,
-        countryPeopleFullyVaccinatedPerHundred
-      } = input.vaccinationData
-        .find((element) => element.threeLetterCountryCode === estimate.countryAlphaThreeCode)?.data
-        .find((element) => estimate.samplingMidDate && element.year === estimate.samplingMidDate.getUTCFullYear().toString())?.data
-        .find((element) => estimate.samplingMidDate && element.month === (estimate.samplingMidDate.getUTCMonth() + 1).toString())?.data
-        .find((element) => estimate.samplingMidDate && element.day === (estimate.samplingMidDate.getUTCDate()).toString()) ?? {
-          countryPeopleVaccinatedPerHundred: undefined,
-          countryPeopleFullyVaccinatedPerHundred: undefined
-        }
-      return {
-        ...estimate,
-        countryPeopleVaccinatedPerHundred,
-        countryPeopleFullyVaccinatedPerHundred
-      }
-    }),
+    allEstimates: input.allEstimates.map((estimate) => ({
+      ...estimate,
+      countryPeopleVaccinatedPerHundred: getAssociatedVaccinationDataForEstimate({
+        estimate: {
+          threeLetterCountryCode: estimate.countryAlphaThreeCode,
+          samplingMidDate: estimate.samplingMidDate
+        },
+        vaccinationData: input.vaccinationData,
+        acceptableDayDifferenceRange
+      }).countryPeopleVaccinatedPerHundred,
+      countryPeopleFullyVaccinatedPerHundred: getAssociatedFullVaccinationDataForEstimate({
+        estimate: {
+          threeLetterCountryCode: estimate.countryAlphaThreeCode,
+          samplingMidDate: estimate.samplingMidDate
+        },
+        vaccinationData: input.vaccinationData,
+        acceptableDayDifferenceRange
+      }).countryPeopleFullyVaccinatedPerHundred
+    })),
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,
     positiveCaseData: input.positiveCaseData,

--- a/src/etl/sars-cov-2/steps/add-vaccination-data-to-estimate-step.ts
+++ b/src/etl/sars-cov-2/steps/add-vaccination-data-to-estimate-step.ts
@@ -8,26 +8,24 @@ import {
 } from "./jitter-pin-lat-lng-step";
 import { StructuredVaccinationData } from "../types";
 
-interface GetAssociatedVaccinationDataForEstimateInput {
+interface GetAssociatedDataForEstimateInput<TKey extends keyof Omit<StructuredVaccinationData[number]['data'][number]['data'][number]['data'][number], 'day'>> {
   estimate: {
     threeLetterCountryCode: string;
     samplingMidDate: Date | undefined;
   };
   vaccinationData: StructuredVaccinationData;
+  fieldName: TKey;
   acceptableDayDifferenceRange: number;
 }
 
-interface GetAssociatedVaccinationDataForEstimateOutput {
-  countryPeopleVaccinatedPerHundred: number | undefined;
-}
-
-const getAssociatedVaccinationDataForEstimate = (input: GetAssociatedVaccinationDataForEstimateInput): GetAssociatedVaccinationDataForEstimateOutput => {
+const getAssociatedVaccinationDataForEstimate = <
+  TKey extends keyof Omit<StructuredVaccinationData[number]['data'][number]['data'][number]['data'][number], 'day'>
+>(input: GetAssociatedDataForEstimateInput<TKey>): StructuredVaccinationData[number]['data'][number]['data'][number]['data'][number][TKey] | undefined => {
   const { samplingMidDate } = input.estimate;
+  const { fieldName } = input;
 
   if(!samplingMidDate) {
-    return {
-      countryPeopleVaccinatedPerHundred: undefined,
-    };
+    return undefined;
   }
 
   const acceptableDayDifferences = [...Array(input.acceptableDayDifferenceRange).keys()];
@@ -47,26 +45,19 @@ const getAssociatedVaccinationDataForEstimate = (input: GetAssociatedVaccination
       .find((element) => element.year === futureDateToEvaluate.getUTCFullYear().toString())?.data
       .find((element) => element.month === (futureDateToEvaluate.getUTCMonth() + 1).toString())?.data
       .find((element) => element.day === (futureDateToEvaluate.getUTCDate()).toString());
+    
+    const fieldForPastDate = dataForPastDateToEvaluate?.[fieldName];
+    const fieldForFutureDate = dataForFutureDateToEvaluate?.[fieldName];
 
     return [(
-      (
-        dataForPastDateToEvaluate !== undefined &&
-        dataForPastDateToEvaluate.countryPeopleVaccinatedPerHundred !== undefined
-      ) ? {
+      fieldForPastDate ? {
         dayDifference: -dayDifference,
-        data: {
-          countryPeopleVaccinatedPerHundred: dataForPastDateToEvaluate.countryPeopleVaccinatedPerHundred,
-        }
+        data: fieldForPastDate
       } : undefined
     ), (
-      (
-        dataForFutureDateToEvaluate !== undefined &&
-        dataForFutureDateToEvaluate.countryPeopleVaccinatedPerHundred !== undefined
-      ) ? {
+      fieldForFutureDate ? {
         dayDifference: dayDifference,
-        data: {
-          countryPeopleVaccinatedPerHundred: dataForFutureDateToEvaluate.countryPeopleVaccinatedPerHundred,
-        }
+        data: fieldForFutureDate
       } : undefined
     )];
   }).filter(<T extends unknown>(element: T | undefined): element is T => element !== undefined)
@@ -74,9 +65,7 @@ const getAssociatedVaccinationDataForEstimate = (input: GetAssociatedVaccination
   const dataForDay = dayDifferencesWithData.find((element) => element.dayDifference === 0)
 
   if(!!dataForDay) {
-    return {
-      countryPeopleVaccinatedPerHundred: dataForDay.data.countryPeopleVaccinatedPerHundred,
-    }
+    return dataForDay.data;
   }
 
   const dayInThePastWithTheLeastDifference = dayDifferencesWithData
@@ -94,128 +83,17 @@ const getAssociatedVaccinationDataForEstimate = (input: GetAssociatedVaccination
     // We approximate the line to be linear on such a small time scale (~14 days).
 
     // m = dy/dx
-    const m = (dayInTheFutureWithTheLeastDifference.data.countryPeopleVaccinatedPerHundred - dayInThePastWithTheLeastDifference.data.countryPeopleVaccinatedPerHundred) / (dayInTheFutureWithTheLeastDifference.dayDifference - dayInThePastWithTheLeastDifference.dayDifference);
+    const m = (dayInTheFutureWithTheLeastDifference.data - dayInThePastWithTheLeastDifference.data) / (dayInTheFutureWithTheLeastDifference.dayDifference - dayInThePastWithTheLeastDifference.dayDifference);
 
     // b = y-mx
-    const b = (dayInTheFutureWithTheLeastDifference.data.countryPeopleVaccinatedPerHundred) - (m * dayInTheFutureWithTheLeastDifference.dayDifference)
+    const b = (dayInTheFutureWithTheLeastDifference.data) - (m * dayInTheFutureWithTheLeastDifference.dayDifference)
 
     // y = mx+b, x=0 in this case because the day difference is zero
-    const countryPeopleVaccinatedPerHundred = (m * 0) + b;
-
-    return {
-      countryPeopleVaccinatedPerHundred
-    }
+    return (m * 0) + b;
   }
 
-  // Getting here means we simply didn't have enough data to tell how many positive cases had occurred at this time.
-  return {
-    countryPeopleVaccinatedPerHundred: undefined
-  }
-}
-
-interface GetAssociatedFullVaccinationDataForEstimateInput {
-  estimate: {
-    threeLetterCountryCode: string;
-    samplingMidDate: Date | undefined;
-  };
-  vaccinationData: StructuredVaccinationData;
-  acceptableDayDifferenceRange: number;
-}
-
-interface GetAssociatedFullVaccinationDataForEstimateOutput {
-  countryPeopleFullyVaccinatedPerHundred: number | undefined;
-}
-
-const getAssociatedFullVaccinationDataForEstimate = (input: GetAssociatedFullVaccinationDataForEstimateInput): GetAssociatedFullVaccinationDataForEstimateOutput => {
-  const { samplingMidDate } = input.estimate;
-
-  if(!samplingMidDate) {
-    return {
-      countryPeopleFullyVaccinatedPerHundred: undefined,
-    };
-  }
-
-  const acceptableDayDifferences = [...Array(input.acceptableDayDifferenceRange).keys()];
-
-  const dayDifferencesWithData = acceptableDayDifferences.flatMap((dayDifference) => {
-    const pastDateToEvaluate = sub(samplingMidDate, {days: dayDifference});
-    const futureDateToEvaluate = add(samplingMidDate, {days: dayDifference});
-
-    const dataForPastDateToEvaluate = input.vaccinationData
-      .find((element) => element.threeLetterCountryCode === input.estimate.threeLetterCountryCode)?.data
-      .find((element) => element.year === pastDateToEvaluate.getUTCFullYear().toString())?.data
-      .find((element) => element.month === (pastDateToEvaluate.getUTCMonth() + 1).toString())?.data
-      .find((element) => element.day === (pastDateToEvaluate.getUTCDate()).toString());
-
-    const dataForFutureDateToEvaluate = input.vaccinationData
-      .find((element) => element.threeLetterCountryCode === input.estimate.threeLetterCountryCode)?.data
-      .find((element) => element.year === futureDateToEvaluate.getUTCFullYear().toString())?.data
-      .find((element) => element.month === (futureDateToEvaluate.getUTCMonth() + 1).toString())?.data
-      .find((element) => element.day === (futureDateToEvaluate.getUTCDate()).toString());
-
-    return [(
-      (
-        dataForPastDateToEvaluate !== undefined &&
-        dataForPastDateToEvaluate.countryPeopleFullyVaccinatedPerHundred !== undefined
-      ) ? {
-        dayDifference: -dayDifference,
-        data: {
-          countryPeopleFullyVaccinatedPerHundred: dataForPastDateToEvaluate.countryPeopleFullyVaccinatedPerHundred,
-        }
-      } : undefined
-    ), (
-      (
-        dataForFutureDateToEvaluate !== undefined &&
-        dataForFutureDateToEvaluate.countryPeopleFullyVaccinatedPerHundred !== undefined
-      ) ? {
-        dayDifference: dayDifference,
-        data: {
-          countryPeopleFullyVaccinatedPerHundred: dataForFutureDateToEvaluate.countryPeopleFullyVaccinatedPerHundred,
-        }
-      } : undefined
-    )];
-  }).filter(<T extends unknown>(element: T | undefined): element is T => element !== undefined)
-
-  const dataForDay = dayDifferencesWithData.find((element) => element.dayDifference === 0)
-
-  if(!!dataForDay) {
-    return {
-      countryPeopleFullyVaccinatedPerHundred: dataForDay.data.countryPeopleFullyVaccinatedPerHundred,
-    }
-  }
-
-  const dayInThePastWithTheLeastDifference = dayDifferencesWithData
-    .filter((element) => element.dayDifference < 0)
-    .sort((a, b) => Math.abs(a.dayDifference) - Math.abs(b.dayDifference))
-    .at(0);
-
-  const dayInTheFutureWithTheLeastDifference = dayDifferencesWithData
-    .filter((element) => element.dayDifference > 0)
-    .sort((a, b) => Math.abs(a.dayDifference) - Math.abs(b.dayDifference))
-    .at(0);
-  
-  if(dayInThePastWithTheLeastDifference && dayInTheFutureWithTheLeastDifference) {
-    // Turn this into a line with a slope of y=mx+b where x is the date.
-    // We approximate the line to be linear on such a small time scale (~14 days).
-
-    // m = dy/dx
-    const m = (dayInTheFutureWithTheLeastDifference.data.countryPeopleFullyVaccinatedPerHundred - dayInThePastWithTheLeastDifference.data.countryPeopleFullyVaccinatedPerHundred) / (dayInTheFutureWithTheLeastDifference.dayDifference - dayInThePastWithTheLeastDifference.dayDifference);
-
-    // b = y-mx
-    const b = (dayInTheFutureWithTheLeastDifference.data.countryPeopleFullyVaccinatedPerHundred) - (m * dayInTheFutureWithTheLeastDifference.dayDifference)
-
-    // y = mx+b, x=0 in this case because the day difference is zero
-    const countryPeopleFullyVaccinatedPerHundred = (m * 0) + b;
-
-    return {
-      countryPeopleFullyVaccinatedPerHundred
-    }
-  }
-
-  // Getting here means we simply didn't have enough data to tell how many positive cases had occurred at this time.
-  return {
-    countryPeopleFullyVaccinatedPerHundred: undefined
-  }
+  // Getting here means we simply didn't have enough data to tell how many vaccinations had occurred at this time.
+  return undefined;
 }
 
 export type EstimateFieldsAfterAddingVaccinationDataStep =
@@ -262,17 +140,19 @@ export const addVaccinationDataToEstimateStep = (
           threeLetterCountryCode: estimate.countryAlphaThreeCode,
           samplingMidDate: estimate.samplingMidDate
         },
+        fieldName: 'countryPeopleVaccinatedPerHundred',
         vaccinationData: input.vaccinationData,
         acceptableDayDifferenceRange
-      }).countryPeopleVaccinatedPerHundred,
-      countryPeopleFullyVaccinatedPerHundred: getAssociatedFullVaccinationDataForEstimate({
+      }),
+      countryPeopleFullyVaccinatedPerHundred: getAssociatedVaccinationDataForEstimate({
         estimate: {
           threeLetterCountryCode: estimate.countryAlphaThreeCode,
           samplingMidDate: estimate.samplingMidDate
         },
+        fieldName: 'countryPeopleFullyVaccinatedPerHundred',
         vaccinationData: input.vaccinationData,
         acceptableDayDifferenceRange
-      }).countryPeopleFullyVaccinatedPerHundred
+      })
     })),
     allStudies: input.allStudies,
     vaccinationData: input.vaccinationData,

--- a/src/etl/sars-cov-2/steps/fetch-positive-case-data-step.ts
+++ b/src/etl/sars-cov-2/steps/fetch-positive-case-data-step.ts
@@ -277,8 +277,8 @@ export const fetchPositiveCaseDataStep = async(
       const split_csv_line = element.split(",");
       const date = split_csv_line[indexOfDateColumn];
       const year = date.split("-")[0]
-      const month = date.split("-")[1]
-      const day = date.split("-")[2]
+      const month = date.split("-")[1].replace(/^0+/, '')
+      const day = date.split("-")[2].replace(/^0+/, '')
 
       return countryCodesWithIndices.map(({ twoLetterCountryCode, indexOfColumn }) => (twoLetterCountryCode ? {
         twoLetterCountryCode,

--- a/src/etl/sars-cov-2/steps/fetch-vaccination-data-step.ts
+++ b/src/etl/sars-cov-2/steps/fetch-vaccination-data-step.ts
@@ -59,8 +59,8 @@ export const fetchVaccinationDataStep = async (
       return {
         threeLetterCountryCode: split_csv_line[indexOfThreeLetterCountryCode],
         year: split_csv_line[indexOfDateColumn].split("-")[0],
-        month: split_csv_line[indexOfDateColumn].split("-")[1],
-        day: split_csv_line[indexOfDateColumn].split("-")[2],
+        month: split_csv_line[indexOfDateColumn].split("-")[1].replace(/^0+/, ''),
+        day: split_csv_line[indexOfDateColumn].split("-")[2].replace(/^0+/, ''),
         countryPeopleVaccinatedPerHundred: split_csv_line[indexOfCountryPeopleVaccinatedPerHundred] !== '' ? parseFloat(split_csv_line[indexOfCountryPeopleVaccinatedPerHundred]) : undefined,
         countryPeopleFullyVaccinatedPerHundred: split_csv_line[indexOfCountryPeopleFullyVaccinatedPerHundred] !== '' ? parseFloat(split_csv_line[indexOfCountryPeopleFullyVaccinatedPerHundred]) : undefined,
       };


### PR DESCRIPTION
Resolves https://github.com/serotracker/dashboard/issues/291.

After the changes, far more data has associated vaccination data and positive case data
```
db.getCollection("sarsCov2Estimates").find().count()
db.getCollection("sarsCov2Estimates").find({countryPeopleFullyVaccinatedPerHundred: {$ne: null}}).count()
db.getCollection("sarsCov2Estimates").find({countryPeopleVaccinatedPerHundred: {$ne: null}}).count()
db.getCollection("sarsCov2Estimates").find({countryPositiveCasesPerMillionPeople: {$ne: null}}).count()
```
```
25418
8101
8766
24531
```

Quick validation with a study from Tajikistan
![image](https://github.com/serotracker/iit-backend-v2/assets/86806388/663521ff-9db7-4c4e-8af1-e5763786c30f)
![image](https://github.com/serotracker/iit-backend-v2/assets/86806388/6c6b2724-9ace-42e6-bbde-7f6a335c7155)
