### PR TITLE
Made the `seroprevalence` field mandatory on the arbo API, made `pathogen` and `unRegion` on the arbo API use the `UNRegion` enum.

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -34,6 +34,53 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "Arbovirus",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CHIKV",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DENV",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MAYV",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "WNV",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "YF",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ZIKV",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "ArbovirusDataStatistics",
         "description": null,
@@ -365,8 +412,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "ENUM",
+                "name": "Arbovirus",
                 "ofType": null
               }
             },
@@ -626,8 +673,8 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
+              "kind": "ENUM",
+              "name": "UNRegion",
               "ofType": null
             },
             "isDeprecated": false,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -490,9 +490,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/api/arbo-resolvers.ts
+++ b/src/api/arbo-resolvers.ts
@@ -1,6 +1,19 @@
 import { MongoClient } from "mongodb";
 import { ArbovirusEstimate, CountryIdentifiers, QueryResolvers } from "./graphql-types/__generated__/graphql-types";
-import { ArbovirusEstimateDocument } from "../storage/types";
+import { Arbovirus, ArbovirusEstimateDocument } from '../storage/types.js';
+import { Arbovirus as ArbovirusForApi } from "./graphql-types/__generated__/graphql-types.js";
+import { mapUnRegionForApi } from "./shared-mappers.js";
+
+const arbovirusMap: {[key in Arbovirus]: ArbovirusForApi} = {
+  [Arbovirus.ZIKV]: ArbovirusForApi.Zikv,
+  [Arbovirus.DENV]: ArbovirusForApi.Denv,
+  [Arbovirus.CHIKV]: ArbovirusForApi.Chikv,
+  [Arbovirus.YF]: ArbovirusForApi.Yf,
+  [Arbovirus.WNV]: ArbovirusForApi.Wnv,
+  [Arbovirus.MAYV]: ArbovirusForApi.Mayv,
+}
+
+const mapArbovirusForApi = (arbovirus: Arbovirus): ArbovirusForApi => arbovirusMap[arbovirus];
 
 interface GenerateArboResolversInput {
   mongoClient: MongoClient;
@@ -32,7 +45,7 @@ const transformArbovirusEstimateDocumentForApi = (document: ArbovirusEstimateDoc
     inclusionCriteria: document.inclusionCriteria,
     latitude: document.latitude,
     longitude: document.longitude,
-    pathogen: document.pathogen,
+    pathogen: mapArbovirusForApi(document.pathogen),
     pediatricAgeGroup: document.pediatricAgeGroup,
     producer: document.producer,
     producerOther: document.producerOther,
@@ -51,7 +64,7 @@ const transformArbovirusEstimateDocumentForApi = (document: ArbovirusEstimateDoc
     sex: document.sex,
     sourceSheetId: document.sourceSheetId,
     sourceSheetName: document.sourceSheetName,
-    unRegion: document.unRegion,
+    unRegion: document.unRegion ? mapUnRegionForApi(document.unRegion) : undefined,
     url: document.url,
     whoRegion: document.whoRegion
   }

--- a/src/api/arbo-typedefs.ts
+++ b/src/api/arbo-typedefs.ts
@@ -28,7 +28,7 @@ export const arboTypedefs = `
     sampleNumerator: Int
     sampleSize: Int!
     sampleStartDate: String
-    seroprevalence: Float
+    seroprevalence: Float!
     seroprevalenceStudy95CILower: Float
     seroprevalenceStudy95CIUpper: Float
     seroprevalenceCalculated95CILower: Float

--- a/src/api/arbo-typedefs.ts
+++ b/src/api/arbo-typedefs.ts
@@ -18,7 +18,7 @@ export const arboTypedefs = `
     inclusionCriteria: String
     latitude: Float!
     longitude: Float!
-    pathogen: String!
+    pathogen: Arbovirus!
     pediatricAgeGroup: String
     producer: String
     producerOther: String
@@ -37,9 +37,18 @@ export const arboTypedefs = `
     sex: String
     sourceSheetId: String
     sourceSheetName: String
-    unRegion: String
+    unRegion: UNRegion
     url: String
     whoRegion: String
+  }
+
+  enum Arbovirus {
+    ZIKV
+    DENV
+    CHIKV
+    YF
+    WNV
+    MAYV
   }
 
   type ArbovirusFilterOptions {

--- a/src/api/graphql-types/__generated__/graphql-types.ts
+++ b/src/api/graphql-types/__generated__/graphql-types.ts
@@ -20,6 +20,15 @@ export type Affiliation = {
   label: Scalars['String']['output'];
 };
 
+export enum Arbovirus {
+  Chikv = 'CHIKV',
+  Denv = 'DENV',
+  Mayv = 'MAYV',
+  Wnv = 'WNV',
+  Yf = 'YF',
+  Zikv = 'ZIKV'
+}
+
 export type ArbovirusDataStatistics = {
   __typename?: 'ArbovirusDataStatistics';
   countryCount: Scalars['Int']['output'];
@@ -47,7 +56,7 @@ export type ArbovirusEstimate = {
   inclusionCriteria?: Maybe<Scalars['String']['output']>;
   latitude: Scalars['Float']['output'];
   longitude: Scalars['Float']['output'];
-  pathogen: Scalars['String']['output'];
+  pathogen: Arbovirus;
   pediatricAgeGroup?: Maybe<Scalars['String']['output']>;
   producer?: Maybe<Scalars['String']['output']>;
   producerOther?: Maybe<Scalars['String']['output']>;
@@ -67,7 +76,7 @@ export type ArbovirusEstimate = {
   sourceSheetId?: Maybe<Scalars['String']['output']>;
   sourceSheetName?: Maybe<Scalars['String']['output']>;
   state?: Maybe<Scalars['String']['output']>;
-  unRegion?: Maybe<Scalars['String']['output']>;
+  unRegion?: Maybe<UnRegion>;
   url?: Maybe<Scalars['String']['output']>;
   whoRegion?: Maybe<Scalars['String']['output']>;
 };
@@ -321,6 +330,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   Affiliation: ResolverTypeWrapper<Affiliation>;
+  Arbovirus: Arbovirus;
   ArbovirusDataStatistics: ResolverTypeWrapper<ArbovirusDataStatistics>;
   ArbovirusEstimate: ResolverTypeWrapper<ArbovirusEstimate>;
   ArbovirusFilterOptions: ResolverTypeWrapper<ArbovirusFilterOptions>;
@@ -390,7 +400,7 @@ export type ArbovirusEstimateResolvers<ContextType = any, ParentType extends Res
   inclusionCriteria?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   latitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   longitude?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
-  pathogen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  pathogen?: Resolver<ResolversTypes['Arbovirus'], ParentType, ContextType>;
   pediatricAgeGroup?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   producer?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   producerOther?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -410,7 +420,7 @@ export type ArbovirusEstimateResolvers<ContextType = any, ParentType extends Res
   sourceSheetId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   sourceSheetName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   state?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  unRegion?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  unRegion?: Resolver<Maybe<ResolversTypes['UNRegion']>, ParentType, ContextType>;
   url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   whoRegion?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/src/api/graphql-types/__generated__/graphql-types.ts
+++ b/src/api/graphql-types/__generated__/graphql-types.ts
@@ -57,7 +57,7 @@ export type ArbovirusEstimate = {
   sampleNumerator?: Maybe<Scalars['Int']['output']>;
   sampleSize: Scalars['Int']['output'];
   sampleStartDate?: Maybe<Scalars['String']['output']>;
-  seroprevalence?: Maybe<Scalars['Float']['output']>;
+  seroprevalence: Scalars['Float']['output'];
   seroprevalenceCalculated95CILower?: Maybe<Scalars['Float']['output']>;
   seroprevalenceCalculated95CIUpper?: Maybe<Scalars['Float']['output']>;
   seroprevalenceStudy95CILower?: Maybe<Scalars['Float']['output']>;
@@ -400,7 +400,7 @@ export type ArbovirusEstimateResolvers<ContextType = any, ParentType extends Res
   sampleNumerator?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   sampleSize?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sampleStartDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  seroprevalence?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  seroprevalence?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   seroprevalenceCalculated95CILower?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   seroprevalenceCalculated95CIUpper?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   seroprevalenceStudy95CILower?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;

--- a/src/etl/arbo/steps/add-country-and-region-information-step.ts
+++ b/src/etl/arbo/steps/add-country-and-region-information-step.ts
@@ -5,14 +5,14 @@ import {
   AirtableSourceFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep,
 } from "./remove-records-that-are-flagged-to-not-save-step.js";
 import { ThreeLetterIsoCountryCode, TwoLetterIsoCountryCode, countryNameToThreeLetterIsoCountryCode, countryNameToTwoLetterIsoCountryCode } from "../../../lib/geocoding-api/country-codes.js";
-import { getUNRegionFromAlphaTwoCode } from "../../../lib/un-regions.js";
+import { UNRegion, getUNRegionFromAlphaTwoCode } from "../../../lib/un-regions.js";
 
 export type AirtableEstimateFieldsAfterAddingCountryAndRegionInformationStep =
   AirtableEstimateFieldsAfterRemovingRecordsThatAreFlaggedToNotSaveStep & {
     country: string;
     countryAlphaTwoCode: TwoLetterIsoCountryCode;
     countryAlphaThreeCode: ThreeLetterIsoCountryCode;
-    unRegion: string | undefined;
+    unRegion: UNRegion | undefined;
   };
 
 export type AirtableSourceFieldsAfterAddingCountryAndRegionInformationStep =

--- a/src/etl/arbo/steps/assert-mandatory-fields-are-present-step.ts
+++ b/src/etl/arbo/steps/assert-mandatory-fields-are-present-step.ts
@@ -8,9 +8,11 @@ import {
 export type AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep =
   Omit<
     AirtableEstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep,
-    "pathogen"
+    | "pathogen"
+    | "seroprevalence"
   > & {
     pathogen: string;
+    seroprevalence: number;
   };
 
 export type AirtableSourceFieldsAfterAssertingMandatoryFieldsArePresentStep =
@@ -42,7 +44,10 @@ export const assertMandatoryFieldsArePresentStep = (
 
   return {
     allEstimates: allEstimates.filter((estimate): estimate is AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep => {
-      return !!estimate.pathogen;
+      return (
+        !!estimate.pathogen &&
+        (estimate.seroprevalence !== undefined && estimate.seroprevalence !== null) 
+      );
     }),
     allSources: allSources,
     allCountries: allCountries,

--- a/src/etl/arbo/steps/assert-mandatory-fields-are-present-step.ts
+++ b/src/etl/arbo/steps/assert-mandatory-fields-are-present-step.ts
@@ -4,6 +4,7 @@ import {
   AirtableEstimateFieldsAfterTransformingNotReportedValuesToUndefinedStep,
   AirtableSourceFieldsAfterTransformingNotReportedValuesToUndefinedStep
 } from "./transform-not-reported-values-to-undefined-step.js";
+import { Arbovirus, isArbovirus } from "../../../storage/types.js";
 
 export type AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep =
   Omit<
@@ -11,7 +12,7 @@ export type AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep =
     | "pathogen"
     | "seroprevalence"
   > & {
-    pathogen: string;
+    pathogen: Arbovirus;
     seroprevalence: number;
   };
 
@@ -46,6 +47,7 @@ export const assertMandatoryFieldsArePresentStep = (
     allEstimates: allEstimates.filter((estimate): estimate is AirtableEstimateFieldsAfterAssertingMandatoryFieldsArePresentStep => {
       return (
         !!estimate.pathogen &&
+        isArbovirus(estimate.pathogen) &&
         (estimate.seroprevalence !== undefined && estimate.seroprevalence !== null) 
       );
     }),

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -20,7 +20,7 @@ export interface ArbovirusEstimateDocument {
   inclusionCriteria: string | undefined;
   pathogen: string;
   pediatricAgeGroup: string | undefined;
-  seroprevalence: number | undefined;
+  seroprevalence: number;
   seroprevalenceStudy95CILower: number | undefined;
   seroprevalenceStudy95CIUpper: number | undefined;
   seroprevalenceCalculated95CILower: number | undefined;

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -3,6 +3,17 @@ import { WHORegion } from "../lib/who-regions";
 import { UNRegion } from "../lib/un-regions";
 import { GBDSubRegion, GBDSuperRegion } from "../lib/gbd-regions";
 
+export enum Arbovirus {
+  ZIKV = "ZIKV",
+  DENV = "DENV",
+  CHIKV = "CHIKV",
+  YF = "YF",
+  WNV = "WNV",
+  MAYV = "MAYV"
+}
+
+export const isArbovirus = (arbovirus: string): arbovirus is Arbovirus => Object.values(Arbovirus).some((element) => element === arbovirus);
+
 export interface ArbovirusEstimateDocument {
   _id: ObjectId;
   sex: string | undefined;
@@ -18,7 +29,7 @@ export interface ArbovirusEstimateDocument {
   serotype: string[];
   sampleNumerator: number | undefined;
   inclusionCriteria: string | undefined;
-  pathogen: string;
+  pathogen: Arbovirus;
   pediatricAgeGroup: string | undefined;
   seroprevalence: number;
   seroprevalenceStudy95CILower: number | undefined;
@@ -36,7 +47,7 @@ export interface ArbovirusEstimateDocument {
   sampleStartDate: Date | undefined;
   sampleEndDate: Date | undefined;
   assay: string | undefined;
-  unRegion: string | undefined;
+  unRegion: UNRegion | undefined;
   url: string | undefined;
   sourceSheetId: string | undefined;
   antigen: string | undefined;


### PR DESCRIPTION
Helps when we do codegen on the front end (See https://github.com/serotracker/dashboard/pull/325). Just baby steps.