### PR TITLE
Fixed a bug with the `ageMinimum` field on estimates in ArboTracker

### DIFF
--- a/src/api/arbo/arbo-resolvers.ts
+++ b/src/api/arbo/arbo-resolvers.ts
@@ -30,7 +30,7 @@ const transformArbovirusEstimateDocumentForApi = (document: ArbovirusEstimateDoc
   return {
     ageGroup: document.ageGroup,
     ageMaximum: document.ageMaximum,
-    ageMinimum: document.ageMaximum,
+    ageMinimum: document.ageMinimum,
     antibodies: document.antibodies ?? [],
     antigen: document.antigen,
     assay: document.assay,


### PR DESCRIPTION
Fixed a bug with the `ageMinimum` field on estimates in ArboTracker