### PR TITLE
Make `animalSpecies` and `animalSpeciesV2` equivalent on the MERSTracker API.

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -877,7 +877,7 @@
               "name": null,
               "ofType": {
                 "kind": "ENUM",
-                "name": "MersEventAnimalSpecies",
+                "name": "MersAnimalSpecies",
                 "ofType": null
               }
             },
@@ -893,7 +893,7 @@
               "name": null,
               "ofType": {
                 "kind": "ENUM",
-                "name": "MersAnimalSpeciesV2",
+                "name": "MersAnimalSpecies",
                 "ofType": null
               }
             },
@@ -3372,7 +3372,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "ENUM",
-                    "name": "MersEventAnimalSpecies",
+                    "name": "MersAnimalSpecies",
                     "ofType": null
                   }
                 }
@@ -3396,7 +3396,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "ENUM",
-                    "name": "MersAnimalSpeciesV2",
+                    "name": "MersAnimalSpecies",
                     "ofType": null
                   }
                 }
@@ -5677,172 +5677,6 @@
             "deprecationReason": null
           },
           {
-            "name": "BAT",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "CAMEL",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "CATTLE",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "DONKEY",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "GOAT",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "SHEEP",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "WATER_BUFFALO",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "MersAnimalSpeciesSubEstimate",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "animalSpecies",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "MersAnimalSpecies",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "animalSpeciesV2",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "MersAnimalSpeciesV2",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "estimateId",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "estimateInfo",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "UNION",
-                "name": "MersSubEstimateInformation",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MersSubEstimateInterface",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "MersAnimalSpeciesV2",
-        "description": null,
-        "isOneOf": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "BABOON",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "BACTRIAN_CAMEL",
             "description": null,
             "isDeprecated": false,
@@ -5909,6 +5743,120 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MersAnimalSpeciesSubEstimate",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "animalSpecies",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "MersAnimalSpecies",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "animalSpeciesV2",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "MersAnimalSpecies",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "estimateId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "estimateInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "UNION",
+                "name": "MersSubEstimateInformation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MersSubEstimateInterface",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -6550,7 +6498,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "ENUM",
-                    "name": "MersAnimalSpeciesV2",
+                    "name": "MersAnimalSpecies",
                     "ofType": null
                   }
                 }
@@ -10633,9 +10581,17 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "ENUM",
-                "name": "MersAnimalSpecies",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "MersAnimalSpecies",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -10656,7 +10612,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "ENUM",
-                    "name": "MersAnimalSpeciesV2",
+                    "name": "MersAnimalSpecies",
                     "ofType": null
                   }
                 }
@@ -11683,9 +11639,17 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "ENUM",
-                "name": "MersAnimalSpecies",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "MersAnimalSpecies",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -11706,7 +11670,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "ENUM",
-                    "name": "MersAnimalSpeciesV2",
+                    "name": "MersAnimalSpecies",
                     "ofType": null
                   }
                 }

--- a/src/api/graphql-types/__generated__/graphql-types.ts
+++ b/src/api/graphql-types/__generated__/graphql-types.ts
@@ -85,8 +85,8 @@ export type AnimalMersEstimate = MersEstimateInterface & {
 
 export type AnimalMersEvent = MersEventInterface & {
   __typename?: 'AnimalMersEvent';
-  animalSpecies: MersEventAnimalSpecies;
-  animalSpeciesV2: MersAnimalSpeciesV2;
+  animalSpecies: MersAnimalSpecies;
+  animalSpeciesV2: MersAnimalSpecies;
   animalType: MersEventAnimalType;
   city: Scalars['String']['output'];
   country: CountryIdentifiers;
@@ -288,8 +288,8 @@ export type CountryIdentifiers = {
 
 export type FaoMersEventFilterOptions = {
   __typename?: 'FaoMersEventFilterOptions';
-  animalSpecies: Array<MersEventAnimalSpecies>;
-  animalSpeciesV2: Array<MersAnimalSpeciesV2>;
+  animalSpecies: Array<MersAnimalSpecies>;
+  animalSpeciesV2: Array<MersAnimalSpecies>;
   animalType: Array<MersEventAnimalType>;
   diagnosisSource: Array<MersDiagnosisSource>;
 };
@@ -487,26 +487,6 @@ export type MersAnimalSourceLocationSubEstimate = MersSubEstimateInterface & {
 
 export enum MersAnimalSpecies {
   Baboon = 'BABOON',
-  Bat = 'BAT',
-  Camel = 'CAMEL',
-  Cattle = 'CATTLE',
-  Donkey = 'DONKEY',
-  Goat = 'GOAT',
-  Sheep = 'SHEEP',
-  WaterBuffalo = 'WATER_BUFFALO'
-}
-
-export type MersAnimalSpeciesSubEstimate = MersSubEstimateInterface & {
-  __typename?: 'MersAnimalSpeciesSubEstimate';
-  animalSpecies: MersAnimalSpecies;
-  animalSpeciesV2: Array<MersAnimalSpeciesV2>;
-  estimateId: Scalars['String']['output'];
-  estimateInfo: MersSubEstimateInformation;
-  id: Scalars['String']['output'];
-};
-
-export enum MersAnimalSpeciesV2 {
-  Baboon = 'BABOON',
   BactrianCamel = 'BACTRIAN_CAMEL',
   Bat = 'BAT',
   Buffalo = 'BUFFALO',
@@ -519,6 +499,15 @@ export enum MersAnimalSpeciesV2 {
   Sheep = 'SHEEP',
   WaterBuffalo = 'WATER_BUFFALO'
 }
+
+export type MersAnimalSpeciesSubEstimate = MersSubEstimateInterface & {
+  __typename?: 'MersAnimalSpeciesSubEstimate';
+  animalSpecies: Array<MersAnimalSpecies>;
+  animalSpeciesV2: Array<MersAnimalSpecies>;
+  estimateId: Scalars['String']['output'];
+  estimateInfo: MersSubEstimateInformation;
+  id: Scalars['String']['output'];
+};
 
 export enum MersAnimalType {
   Domestic = 'DOMESTIC',
@@ -578,7 +567,7 @@ export type MersEstimateFilterOptions = {
   animalImportedOrLocal: Array<Scalars['String']['output']>;
   animalPurpose: Array<Scalars['String']['output']>;
   animalSpecies: Array<MersAnimalSpecies>;
-  animalSpeciesV2: Array<MersAnimalSpeciesV2>;
+  animalSpeciesV2: Array<MersAnimalSpecies>;
   antigen: Array<Scalars['String']['output']>;
   assay: Array<Scalars['String']['output']>;
   clade: Array<Clade>;
@@ -937,8 +926,8 @@ export type PrimaryAnimalMersSeroprevalenceEstimateInformation = PrimaryMersEsti
   animalDetectionSettings: Array<Scalars['String']['output']>;
   animalImportedOrLocal?: Maybe<Scalars['String']['output']>;
   animalPurpose?: Maybe<Scalars['String']['output']>;
-  animalSpecies: MersAnimalSpecies;
-  animalSpeciesV2: Array<MersAnimalSpeciesV2>;
+  animalSpecies: Array<MersAnimalSpecies>;
+  animalSpeciesV2: Array<MersAnimalSpecies>;
   animalType: Array<MersAnimalType>;
   antigen: Array<Scalars['String']['output']>;
   assay: Array<Scalars['String']['output']>;
@@ -1008,8 +997,8 @@ export type PrimaryAnimalMersViralEstimateInformation = PrimaryMersEstimateInfor
   animalDetectionSettings: Array<Scalars['String']['output']>;
   animalImportedOrLocal?: Maybe<Scalars['String']['output']>;
   animalPurpose?: Maybe<Scalars['String']['output']>;
-  animalSpecies: MersAnimalSpecies;
-  animalSpeciesV2: Array<MersAnimalSpeciesV2>;
+  animalSpecies: Array<MersAnimalSpecies>;
+  animalSpeciesV2: Array<MersAnimalSpecies>;
   animalType: Array<MersAnimalType>;
   antigen: Array<Scalars['String']['output']>;
   assay: Array<Scalars['String']['output']>;
@@ -1560,7 +1549,6 @@ export type ResolversTypes = {
   MersAnimalSourceLocationSubEstimate: ResolverTypeWrapper<Omit<MersAnimalSourceLocationSubEstimate, 'estimateInfo'> & { estimateInfo: ResolversTypes['MersSubEstimateInformation'] }>;
   MersAnimalSpecies: MersAnimalSpecies;
   MersAnimalSpeciesSubEstimate: ResolverTypeWrapper<Omit<MersAnimalSpeciesSubEstimate, 'estimateInfo'> & { estimateInfo: ResolversTypes['MersSubEstimateInformation'] }>;
-  MersAnimalSpeciesV2: MersAnimalSpeciesV2;
   MersAnimalType: MersAnimalType;
   MersCamelExposureLevelSubEstimate: ResolverTypeWrapper<Omit<MersCamelExposureLevelSubEstimate, 'estimateInfo'> & { estimateInfo: ResolversTypes['MersSubEstimateInformation'] }>;
   MersDiagnosisSource: MersDiagnosisSource;
@@ -1765,8 +1753,8 @@ export type AnimalMersEstimateResolvers<ContextType = any, ParentType extends Re
 };
 
 export type AnimalMersEventResolvers<ContextType = any, ParentType extends ResolversParentTypes['AnimalMersEvent'] = ResolversParentTypes['AnimalMersEvent']> = {
-  animalSpecies?: Resolver<ResolversTypes['MersEventAnimalSpecies'], ParentType, ContextType>;
-  animalSpeciesV2?: Resolver<ResolversTypes['MersAnimalSpeciesV2'], ParentType, ContextType>;
+  animalSpecies?: Resolver<ResolversTypes['MersAnimalSpecies'], ParentType, ContextType>;
+  animalSpeciesV2?: Resolver<ResolversTypes['MersAnimalSpecies'], ParentType, ContextType>;
   animalType?: Resolver<ResolversTypes['MersEventAnimalType'], ParentType, ContextType>;
   city?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   country?: Resolver<ResolversTypes['CountryIdentifiers'], ParentType, ContextType>;
@@ -1939,8 +1927,8 @@ export type CountryIdentifiersResolvers<ContextType = any, ParentType extends Re
 };
 
 export type FaoMersEventFilterOptionsResolvers<ContextType = any, ParentType extends ResolversParentTypes['FaoMersEventFilterOptions'] = ResolversParentTypes['FaoMersEventFilterOptions']> = {
-  animalSpecies?: Resolver<Array<ResolversTypes['MersEventAnimalSpecies']>, ParentType, ContextType>;
-  animalSpeciesV2?: Resolver<Array<ResolversTypes['MersAnimalSpeciesV2']>, ParentType, ContextType>;
+  animalSpecies?: Resolver<Array<ResolversTypes['MersAnimalSpecies']>, ParentType, ContextType>;
+  animalSpeciesV2?: Resolver<Array<ResolversTypes['MersAnimalSpecies']>, ParentType, ContextType>;
   animalType?: Resolver<Array<ResolversTypes['MersEventAnimalType']>, ParentType, ContextType>;
   diagnosisSource?: Resolver<Array<ResolversTypes['MersDiagnosisSource']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -2097,8 +2085,8 @@ export type MersAnimalSourceLocationSubEstimateResolvers<ContextType = any, Pare
 };
 
 export type MersAnimalSpeciesSubEstimateResolvers<ContextType = any, ParentType extends ResolversParentTypes['MersAnimalSpeciesSubEstimate'] = ResolversParentTypes['MersAnimalSpeciesSubEstimate']> = {
-  animalSpecies?: Resolver<ResolversTypes['MersAnimalSpecies'], ParentType, ContextType>;
-  animalSpeciesV2?: Resolver<Array<ResolversTypes['MersAnimalSpeciesV2']>, ParentType, ContextType>;
+  animalSpecies?: Resolver<Array<ResolversTypes['MersAnimalSpecies']>, ParentType, ContextType>;
+  animalSpeciesV2?: Resolver<Array<ResolversTypes['MersAnimalSpecies']>, ParentType, ContextType>;
   estimateId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   estimateInfo?: Resolver<ResolversTypes['MersSubEstimateInformation'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -2143,7 +2131,7 @@ export type MersEstimateFilterOptionsResolvers<ContextType = any, ParentType ext
   animalImportedOrLocal?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   animalPurpose?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   animalSpecies?: Resolver<Array<ResolversTypes['MersAnimalSpecies']>, ParentType, ContextType>;
-  animalSpeciesV2?: Resolver<Array<ResolversTypes['MersAnimalSpeciesV2']>, ParentType, ContextType>;
+  animalSpeciesV2?: Resolver<Array<ResolversTypes['MersAnimalSpecies']>, ParentType, ContextType>;
   antigen?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   assay?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   clade?: Resolver<Array<ResolversTypes['Clade']>, ParentType, ContextType>;
@@ -2442,8 +2430,8 @@ export type PrimaryAnimalMersSeroprevalenceEstimateInformationResolvers<ContextT
   animalDetectionSettings?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   animalImportedOrLocal?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   animalPurpose?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  animalSpecies?: Resolver<ResolversTypes['MersAnimalSpecies'], ParentType, ContextType>;
-  animalSpeciesV2?: Resolver<Array<ResolversTypes['MersAnimalSpeciesV2']>, ParentType, ContextType>;
+  animalSpecies?: Resolver<Array<ResolversTypes['MersAnimalSpecies']>, ParentType, ContextType>;
+  animalSpeciesV2?: Resolver<Array<ResolversTypes['MersAnimalSpecies']>, ParentType, ContextType>;
   animalType?: Resolver<Array<ResolversTypes['MersAnimalType']>, ParentType, ContextType>;
   antigen?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   assay?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
@@ -2513,8 +2501,8 @@ export type PrimaryAnimalMersViralEstimateInformationResolvers<ContextType = any
   animalDetectionSettings?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   animalImportedOrLocal?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   animalPurpose?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  animalSpecies?: Resolver<ResolversTypes['MersAnimalSpecies'], ParentType, ContextType>;
-  animalSpeciesV2?: Resolver<Array<ResolversTypes['MersAnimalSpeciesV2']>, ParentType, ContextType>;
+  animalSpecies?: Resolver<Array<ResolversTypes['MersAnimalSpecies']>, ParentType, ContextType>;
+  animalSpeciesV2?: Resolver<Array<ResolversTypes['MersAnimalSpecies']>, ParentType, ContextType>;
   animalType?: Resolver<Array<ResolversTypes['MersAnimalType']>, ParentType, ContextType>;
   antigen?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   assay?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;

--- a/src/api/mers/mers-estimate-resolvers.ts
+++ b/src/api/mers/mers-estimate-resolvers.ts
@@ -13,7 +13,6 @@ import {
 import {
   QueryResolvers,
   MersAnimalSpecies as MersAnimalSpeciesForApi,
-  MersAnimalSpeciesV2 as MersAnimalSpeciesV2ForApi,
   MersAnimalType as MersAnimalTypeForApi,
   MersEstimateType as MersEstimateTypeForApi,
   Clade as CladeForApi,
@@ -29,40 +28,21 @@ import {
 import { mapUnRegionForApi, mapWhoRegionForApi } from "../shared/shared-mappers.js";
 import uniq from "lodash/uniq.js";
 
-export const mersAnimalSpeciesMapForApi = {
+export const mersAnimalSpeciesV2MapForApi = {
   [MersAnimalSpecies.BAT]: MersAnimalSpeciesForApi.Bat,
   [MersAnimalSpecies.GOAT]: MersAnimalSpeciesForApi.Goat,
-  [MersAnimalSpecies.DROMEDARY_CAMEL]: MersAnimalSpeciesForApi.Camel,
-  [MersAnimalSpecies.BACTRIAN_CAMEL]: MersAnimalSpeciesForApi.Camel,
-  //TODO fix this up Sean.
-  [MersAnimalSpecies.HORSE]: MersAnimalSpeciesForApi.Camel,
-  //TODO fix this up Sean.
-  [MersAnimalSpecies.MULE]: MersAnimalSpeciesForApi.Camel,
-  //TODO fix this up Sean.
-  [MersAnimalSpecies.BUFFALO]: MersAnimalSpeciesForApi.WaterBuffalo,
+  [MersAnimalSpecies.DROMEDARY_CAMEL]: MersAnimalSpeciesForApi.DromedaryCamel,
+  [MersAnimalSpecies.BACTRIAN_CAMEL]: MersAnimalSpeciesForApi.BactrianCamel,
+  [MersAnimalSpecies.MULE]: MersAnimalSpeciesForApi.Mule,
+  [MersAnimalSpecies.BUFFALO]: MersAnimalSpeciesForApi.Buffalo,
+  [MersAnimalSpecies.HORSE]: MersAnimalSpeciesForApi.Horse,
   [MersAnimalSpecies.CATTLE]: MersAnimalSpeciesForApi.Cattle,
   [MersAnimalSpecies.SHEEP]: MersAnimalSpeciesForApi.Sheep,
   [MersAnimalSpecies.DONKEY]: MersAnimalSpeciesForApi.Donkey,
   [MersAnimalSpecies.WATER_BUFFALO]: MersAnimalSpeciesForApi.WaterBuffalo,
   [MersAnimalSpecies.BABOON]: MersAnimalSpeciesForApi.Baboon
 }
-
-export const mersAnimalSpeciesV2MapForApi = {
-  [MersAnimalSpecies.BAT]: MersAnimalSpeciesV2ForApi.Bat,
-  [MersAnimalSpecies.GOAT]: MersAnimalSpeciesV2ForApi.Goat,
-  [MersAnimalSpecies.DROMEDARY_CAMEL]: MersAnimalSpeciesV2ForApi.DromedaryCamel,
-  [MersAnimalSpecies.BACTRIAN_CAMEL]: MersAnimalSpeciesV2ForApi.BactrianCamel,
-  [MersAnimalSpecies.MULE]: MersAnimalSpeciesV2ForApi.Mule,
-  [MersAnimalSpecies.BUFFALO]: MersAnimalSpeciesV2ForApi.Buffalo,
-  [MersAnimalSpecies.HORSE]: MersAnimalSpeciesV2ForApi.Horse,
-  [MersAnimalSpecies.CATTLE]: MersAnimalSpeciesV2ForApi.Cattle,
-  [MersAnimalSpecies.SHEEP]: MersAnimalSpeciesV2ForApi.Sheep,
-  [MersAnimalSpecies.DONKEY]: MersAnimalSpeciesV2ForApi.Donkey,
-  [MersAnimalSpecies.WATER_BUFFALO]: MersAnimalSpeciesV2ForApi.WaterBuffalo,
-  [MersAnimalSpecies.BABOON]: MersAnimalSpeciesV2ForApi.Baboon
-}
-export const mapMersAnimalSpeciesForApi = (animalSpecies: MersAnimalSpecies): MersAnimalSpeciesForApi => mersAnimalSpeciesMapForApi[animalSpecies];
-export const mapMersAnimalSpeciesV2ForApi = (animalSpecies: MersAnimalSpecies): MersAnimalSpeciesV2ForApi => mersAnimalSpeciesV2MapForApi[animalSpecies];
+export const mapMersAnimalSpeciesForApi = (animalSpecies: MersAnimalSpecies): MersAnimalSpeciesForApi => mersAnimalSpeciesV2MapForApi[animalSpecies];
 
 const mersAnimalTypeMapForApi = {
   [MersAnimalType.WILD]: MersAnimalTypeForApi.Wild,
@@ -176,8 +156,8 @@ const getPrimaryMersEstimateInformationForDocument = (document: MersPrimaryEstim
       seroprevalenceCalculated95CILower: document.seroprevalenceCalculated95CILower,
       seroprevalenceCalculated95CIUpper: document.seroprevalenceCalculated95CIUpper,
       type: MersEstimateTypeForApi.AnimalSeroprevalence,
-      animalSpecies: mapMersAnimalSpeciesForApi(document.animalSpecies[0]),
-      animalSpeciesV2: document.animalSpecies.map((animalSpecies) => mapMersAnimalSpeciesV2ForApi(animalSpecies)),
+      animalSpecies: document.animalSpecies.map((animalSpecies) => mapMersAnimalSpeciesForApi(animalSpecies)),
+      animalSpeciesV2: document.animalSpecies.map((animalSpecies) => mapMersAnimalSpeciesForApi(animalSpecies)),
       animalType: document.animalType.map((animalType) => (mapMersAnimalTypeForApi(animalType))),
       animalDetectionSettings: document.animalDetectionSettings,
       animalPurpose: document.animalPurpose,
@@ -222,8 +202,8 @@ const getPrimaryMersEstimateInformationForDocument = (document: MersPrimaryEstim
       positivePrevalenceCalculated95CILower: document.positivePrevalenceCalculated95CILower,
       positivePrevalenceCalculated95CIUpper: document.positivePrevalenceCalculated95CIUpper,
       type: MersEstimateTypeForApi.AnimalViral,
-      animalSpecies: mapMersAnimalSpeciesForApi(document.animalSpecies[0]),
-      animalSpeciesV2: document.animalSpecies.map((animalSpecies) => mapMersAnimalSpeciesV2ForApi(animalSpecies)),
+      animalSpecies: document.animalSpecies.map((animalSpecies) => mapMersAnimalSpeciesForApi(animalSpecies)),
+      animalSpeciesV2: document.animalSpecies.map((animalSpecies) => mapMersAnimalSpeciesForApi(animalSpecies)),
       animalType: document.animalType.map((animalType) => (mapMersAnimalTypeForApi(animalType))),
       animalDetectionSettings: document.animalDetectionSettings,
       animalPurpose: document.animalPurpose,
@@ -324,8 +304,8 @@ export const generateMersEstimateResolvers = (input: GenerateMersEstimateResolve
       animalSpeciesSubestimates: primaryEstimate.animalSpeciesSubestimates.map((subestimate) => ({
         ...mapMersSubEstimateBaseForApi(subestimate),
         __typename: 'MersAnimalSpeciesSubEstimate' as const,
-        animalSpecies: mapMersAnimalSpeciesForApi(subestimate.animalSpecies[0]),
-        animalSpeciesV2: subestimate.animalSpecies.map((animalSpecies) => mapMersAnimalSpeciesV2ForApi(animalSpecies)),
+        animalSpecies: subestimate.animalSpecies.map((animalSpecies) => mapMersAnimalSpeciesForApi(animalSpecies)),
+        animalSpeciesV2: subestimate.animalSpecies.map((animalSpecies) => mapMersAnimalSpeciesForApi(animalSpecies)),
       })),
       sexSubestimates: primaryEstimate.sexSubestimates.map((subestimate) => ({
         ...mapMersSubEstimateBaseForApi(subestimate),
@@ -412,7 +392,7 @@ export const generateMersEstimateResolvers = (input: GenerateMersEstimateResolve
       animalSpecies: uniq(mersEstimateFilterOptions?.animalSpecies
         .map((element) => mapMersAnimalSpeciesForApi(element)) ?? []),
       animalSpeciesV2: uniq(mersEstimateFilterOptions?.animalSpecies
-        .map((element) => mapMersAnimalSpeciesV2ForApi(element)) ?? []),
+        .map((element) => mapMersAnimalSpeciesForApi(element)) ?? []),
       animalImportedOrLocal: mersEstimateFilterOptions?.animalImportedOrLocal ?? [],
       sampleFrame: mersEstimateFilterOptions?.sampleFrame ?? [],
       exposureToCamels: mersEstimateFilterOptions?.exposureToCamels ?? [],

--- a/src/api/mers/mers-estimate-typedefs.ts
+++ b/src/api/mers/mers-estimate-typedefs.ts
@@ -5,17 +5,6 @@ export const mersEstimateTypedefs = `
   }
 
   enum MersAnimalSpecies {
-    CAMEL
-    BAT
-    GOAT
-    SHEEP
-    CATTLE
-    DONKEY
-    WATER_BUFFALO
-    BABOON
-  }
-
-  enum MersAnimalSpeciesV2 {
     BAT
     GOAT
     SHEEP
@@ -57,7 +46,7 @@ export const mersEstimateTypedefs = `
     animalPurpose: [String!]!
     animalImportedOrLocal: [String!]!
     animalSpecies: [MersAnimalSpecies!]!
-    animalSpeciesV2: [MersAnimalSpeciesV2!]!
+    animalSpeciesV2: [MersAnimalSpecies!]!
     sampleFrame: [String!]!
     exposureToCamels: [String!]!
     antigen: [String!]!
@@ -263,8 +252,8 @@ export const mersEstimateTypedefs = `
     positivePrevalenceCalculated95CILower: Float!
     positivePrevalenceCalculated95CIUpper: Float!
     animalType: [MersAnimalType!]!
-    animalSpecies: MersAnimalSpecies!
-    animalSpeciesV2: [MersAnimalSpeciesV2!]!
+    animalSpecies: [MersAnimalSpecies!]!
+    animalSpeciesV2: [MersAnimalSpecies!]!
     animalDetectionSettings: [String!]!
     animalPurpose: String
     animalImportedOrLocal: String
@@ -405,8 +394,8 @@ export const mersEstimateTypedefs = `
     seroprevalenceCalculated95CILower: Float!
     seroprevalenceCalculated95CIUpper: Float!
     animalType: [MersAnimalType!]!
-    animalSpecies: MersAnimalSpecies!
-    animalSpeciesV2: [MersAnimalSpeciesV2!]!
+    animalSpecies: [MersAnimalSpecies!]!
+    animalSpeciesV2: [MersAnimalSpecies!]!
     animalDetectionSettings: [String!]!
     animalPurpose: String
     animalImportedOrLocal: String
@@ -516,8 +505,8 @@ export const mersEstimateTypedefs = `
     estimateInfo: MersSubEstimateInformation!
     ####### END INTERFACE FIELDS #######
 
-    animalSpecies: MersAnimalSpecies!
-    animalSpeciesV2: [MersAnimalSpeciesV2!]!
+    animalSpecies: [MersAnimalSpecies!]!
+    animalSpeciesV2: [MersAnimalSpecies!]!
   }
 
   type MersSexSubEstimate implements MersSubEstimateInterface {

--- a/src/api/mers/mers-event-resolvers.ts
+++ b/src/api/mers/mers-event-resolvers.ts
@@ -16,13 +16,12 @@ import {
   MersEventAnimalSpecies as MersEventAnimalSpeciesForApi,
   MersDiagnosisStatus as MersDiagnosisStatusForApi,
   MersDiagnosisSource as MersDiagnosisSourceForApi,
-  MersAnimalSpeciesV2 as MersAnimalSpeciesV2ForApi,
+  MersAnimalSpecies as MersAnimalSpeciesForApi,
   QueryResolvers,
   MersEventInterface,
   MersEvent
 } from "../graphql-types/__generated__/graphql-types.js";
 import { mapUnRegionForApi, mapWhoRegionForApi } from "../shared/shared-mappers.js";
-import { mapMersAnimalSpeciesV2ForApi } from "./mers-estimate-resolvers.js";
 
 interface GenerateMersEventResolversInput {
   mongoClient: MongoClient;
@@ -32,44 +31,20 @@ interface GenerateMersEventResolversOutput {
   mersEventResolvers: { Query: QueryResolvers }
 }
 
-const faoMersEventAnimalSpeciesMap = {
-  [MersEventAnimalSpecies.BAT]: MersEventAnimalSpeciesForApi.Bat,
-  [MersEventAnimalSpecies.GOAT]: MersEventAnimalSpeciesForApi.Goat,
-  [MersEventAnimalSpecies.CATTLE]: MersEventAnimalSpeciesForApi.Cattle,
-  [MersEventAnimalSpecies.SHEEP]: MersEventAnimalSpeciesForApi.Sheep,
-  [MersEventAnimalSpecies.DONKEY]: MersEventAnimalSpeciesForApi.Donkey,
-  [MersEventAnimalSpecies.WATER_BUFFALO]: MersEventAnimalSpeciesForApi.WaterBuffalo,
-  [MersEventAnimalSpecies.BABOON]: MersEventAnimalSpeciesForApi.Baboon,
-  //TODO fix this up Sean.
-  [MersEventAnimalSpecies.HORSE]: MersEventAnimalSpeciesForApi.Camel,
-  //TODO fix this up Sean.
-  [MersEventAnimalSpecies.MULE]: MersEventAnimalSpeciesForApi.Camel,
-  //TODO fix this up Sean.
-  [MersEventAnimalSpecies.DROMEDARY_CAMEL]: MersEventAnimalSpeciesForApi.Camel,
-  //TODO fix this up Sean.
-  [MersEventAnimalSpecies.BACTRIAN_CAMEL]: MersEventAnimalSpeciesForApi.Camel,
-  //TODO fix this up Sean.
-  [MersEventAnimalSpecies.BUFFALO]: MersEventAnimalSpeciesForApi.WaterBuffalo,
-}
-
 export const mersAnimalSpeciesV2MapForApi = {
-  [MersEventAnimalSpecies.BAT]: MersAnimalSpeciesV2ForApi.Bat,
-  [MersEventAnimalSpecies.GOAT]: MersAnimalSpeciesV2ForApi.Goat,
-  [MersEventAnimalSpecies.DROMEDARY_CAMEL]: MersAnimalSpeciesV2ForApi.DromedaryCamel,
-  [MersEventAnimalSpecies.BACTRIAN_CAMEL]: MersAnimalSpeciesV2ForApi.BactrianCamel,
-  [MersEventAnimalSpecies.MULE]: MersAnimalSpeciesV2ForApi.Mule,
-  [MersEventAnimalSpecies.BUFFALO]: MersAnimalSpeciesV2ForApi.Buffalo,
-  [MersEventAnimalSpecies.HORSE]: MersAnimalSpeciesV2ForApi.Horse,
-  [MersEventAnimalSpecies.CATTLE]: MersAnimalSpeciesV2ForApi.Cattle,
-  [MersEventAnimalSpecies.SHEEP]: MersAnimalSpeciesV2ForApi.Sheep,
-  [MersEventAnimalSpecies.DONKEY]: MersAnimalSpeciesV2ForApi.Donkey,
-  [MersEventAnimalSpecies.WATER_BUFFALO]: MersAnimalSpeciesV2ForApi.WaterBuffalo,
-  [MersEventAnimalSpecies.BABOON]: MersAnimalSpeciesV2ForApi.Baboon
+  [MersEventAnimalSpecies.BAT]: MersAnimalSpeciesForApi.Bat,
+  [MersEventAnimalSpecies.GOAT]: MersAnimalSpeciesForApi.Goat,
+  [MersEventAnimalSpecies.DROMEDARY_CAMEL]: MersAnimalSpeciesForApi.DromedaryCamel,
+  [MersEventAnimalSpecies.BACTRIAN_CAMEL]: MersAnimalSpeciesForApi.BactrianCamel,
+  [MersEventAnimalSpecies.MULE]: MersAnimalSpeciesForApi.Mule,
+  [MersEventAnimalSpecies.BUFFALO]: MersAnimalSpeciesForApi.Buffalo,
+  [MersEventAnimalSpecies.HORSE]: MersAnimalSpeciesForApi.Horse,
+  [MersEventAnimalSpecies.CATTLE]: MersAnimalSpeciesForApi.Cattle,
+  [MersEventAnimalSpecies.SHEEP]: MersAnimalSpeciesForApi.Sheep,
+  [MersEventAnimalSpecies.DONKEY]: MersAnimalSpeciesForApi.Donkey,
+  [MersEventAnimalSpecies.WATER_BUFFALO]: MersAnimalSpeciesForApi.WaterBuffalo,
+  [MersEventAnimalSpecies.BABOON]: MersAnimalSpeciesForApi.Baboon
 }
-
-
-const transformFaoMersEventAnimalSpeciesForApi = (animalSpecies: MersEventAnimalSpecies): MersEventAnimalSpeciesForApi => 
-  faoMersEventAnimalSpeciesMap[animalSpecies];
 
 const faoMersEventAnimalTypeMap = {
   [MersEventAnimalType.DOMESTIC]: MersEventAnimalTypeForApi.Domestic,
@@ -123,7 +98,7 @@ const transformFaoMersEventDocumentForApi = (document: FaoMersEventDocument): Me
       ...transformFaoMersEventDocumentBaseForApi(document),
       __typename: "AnimalMersEvent",
       type: MersEventTypeForApi.Animal,
-      animalSpecies: transformFaoMersEventAnimalSpeciesForApi(document.animalSpecies),
+      animalSpecies: mersAnimalSpeciesV2MapForApi[document.animalSpecies],
       animalSpeciesV2: mersAnimalSpeciesV2MapForApi[document.animalSpecies],
       animalType: transformFaoMersEventAnimalTypeForApi(document.animalType),
     }
@@ -166,7 +141,7 @@ export const generateMersEventResolvers = (input: GenerateMersEventResolversInpu
     return {
       diagnosisSource: diagnosisSource.map((element) => transformFaoMersEventDiagnosisSourceForApi(element)),
       animalType: animalType.map((element) => transformFaoMersEventAnimalTypeForApi(element)),
-      animalSpecies: animalSpecies.map((element) => transformFaoMersEventAnimalSpeciesForApi(element)),
+      animalSpecies: animalSpecies.map((element) => mersAnimalSpeciesV2MapForApi[element]),
       animalSpeciesV2: animalSpecies.map((element) => mersAnimalSpeciesV2MapForApi[element]),
     }
   }

--- a/src/api/mers/mers-event-typedefs.ts
+++ b/src/api/mers/mers-event-typedefs.ts
@@ -68,8 +68,8 @@ export const mersEventTypedefs = `
     ####### END INTERFACE FIELDS #######
 
     animalType: MersEventAnimalType!
-    animalSpecies: MersEventAnimalSpecies!
-    animalSpeciesV2: MersAnimalSpeciesV2!
+    animalSpecies: MersAnimalSpecies!
+    animalSpeciesV2: MersAnimalSpecies!
   }
 
   type HumanMersEvent implements MersEventInterface {
@@ -107,8 +107,8 @@ export const mersEventTypedefs = `
   type FaoMersEventFilterOptions {
     diagnosisSource: [MersDiagnosisSource!]!
     animalType: [MersEventAnimalType!]!
-    animalSpecies: [MersEventAnimalSpecies!]!
-    animalSpeciesV2: [MersAnimalSpeciesV2!]!
+    animalSpecies: [MersAnimalSpecies!]!
+    animalSpeciesV2: [MersAnimalSpecies!]!
   }
 
   type Query {


### PR DESCRIPTION
Make animalSpecies and animalSpeciesV2 equivalent on the MERSTracker API.